### PR TITLE
Add minimal helm chart with admin/test login

### DIFF
--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: nigrafana
+description: A Helm chart that deploys Grafana and a Postgres database cluster for it
+
+type: application
+dependencies:
+  - name: grafana
+    version: ~6.20.6
+    repository: "https://grafana.github.io/helm-charts"
+
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,3 @@
+grafana:
+  adminUser: admin
+  adminPassword: test


### PR DESCRIPTION

**What this PR does / why we need it**:

Just adding a minimal helm chart skeleton. A follow-up PR will modify `azure-pipelines.yml` to package and publish the chart.

**Which issue(s) this PR fixes**:

https://ni.visualstudio.com/DevCentral/_workitems/edit/1799084

**Special notes for your reviewer**:

Adding temporary hardcoded login credentials is technically in another story, but I wanted to put something in the `values.yml` now, and not having predefined credentials was going to make testing a pain anyways. Note that I was going to use a username/password combination that is more common at NI, but we're in a public github repo and I didn't want those internal credentials in the commit history.

Testing steps:
`cd helm`
`helm install nigrafana .`
`kubectl get-pods`
*copy/paste the name of the grafana pod*
`kubectl port-forward pod_name_here 3000:3000`
*Login via admin/test at localhost:3000 in my browser*
