### PR TITLE
Add PR merge workflow

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,19 @@
+name: PR Merged
+
+on:
+  pull_request:
+    branches:
+      - ni/priv
+      - ni/pub/*
+    types: [closed]
+
+jobs:
+  main:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ni/current
+      - run: git rebase ${{ github.ref }}
+      - run: git push

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   main:
     if: github.event.pull_request.merged == true
+    environment: main
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I realized that a pain point we'll have with our current branch model is that updating ni/current with either ni/priv changes or new ni/pub branches will be a manual process. So after every merge we'll have to rebase, and if we forget then ni/current will fall behind, which isn't great given that it's the default branch.

This is an attempt at adding a GitHub workflow that will do this automatically for us. 