### PR TITLE
Install SystemLink Notebook datasource plugin in Dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,13 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
+ENV NI_PLUGINS_VERSION="2022-02-07T234351"
+RUN wget https://github.com/ni/grafana-plugins/releases/download/${NI_PLUGINS_VERSION}/${NI_PLUGINS_VERSION}-grafana-plugins.zip -O grafana-plugins.zip  && \
+  unzip grafana-plugins.zip -d /grafana-plugins && \
+  cp -r /grafana-plugins/plugins/systemlink-notebook-datasource $GF_PATHS_PLUGINS && \
+  rm -rf grafana-plugins && \
+  rm grafana-plugins.zip
+
 COPY --from=go-builder /grafana/bin/*/grafana-server /grafana/bin/*/grafana-cli ./bin/
 COPY --from=js-builder /grafana/public ./public
 COPY --from=js-builder /grafana/tools ./tools


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to install our Jupyter Notebooks datasource plugin with grafana. As long as our plugin is unsigned, we have decided to do this by baking it into the image built from our fork. This change adds a command to the Dockerfile to download the plugin from github and copy the plugin files to the expected plugin location.

**Which issue(s) this PR fixes**:
https://dev.azure.com/ni/DevCentral/_workitems/edit/1800806

**Special notes for your reviewer**:
To test locally, add `allow_loading_unsigned_plugins = systemlink-notebook-datasource` to conf/defaults.ini. Without this, you won't see the plugin when you go to add the datasource in the UI. We'll be setting this through the helm chart config as part of a [future user story](https://dev.azure.com/ni/DevCentral/_workitems/edit/1799100).

Steps to test:
- In the folder with the Dockerfile, run `docker build -t image-tag-name .`
- `docker run -d -p 3000:3000 --name container-name image-tag-name` (or run the image from Docker desktop)
- `docker exec -it container-name /bin/bash` if you want to inspect the files copied, or
- go to localhost:3000
- Go to Configuration>>Data sources, click Add data source, use the filter to find SystemLink Notebooks.