### PR TITLE
Tag images in ECR with latest, in addition to the versioned tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,8 @@ steps:
       latest
 
 - task: ECRPushImage@1
-  displayName: Push docker image
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
+  displayName: Push docker image with versioned tag
   inputs:
     awsCredentials: 'AWS SystemLink Cloud'
     regionName: 'us-east-1'
@@ -40,8 +41,10 @@ steps:
     pushTag: '$(ImageVersion)'
     autoCreateRepository: true
 
+# Push a second time to additionally tag the image with the 'latest' tag (the second push is instantaneous)
 - task: ECRPushImage@1
-  displayName: Push docker image
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
+  displayName: Tag image with latest
   inputs:
     awsCredentials: 'AWS SystemLink Cloud'
     regionName: 'us-east-1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,20 +24,20 @@ steps:
     repository: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
     command: 'build'
     Dockerfile: 'Dockerfile'
-    tags: '$(ImageVersion)'
+    tags: |
+      $(ImageVersion)
+      latest
 
-- task: ECRPushImage@1
+- task: Docker@2
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
   displayName: Push docker image
   inputs:
-    awsCredentials: 'AWS SystemLink Cloud'
-    regionName: 'us-east-1'
-    imageSource: 'imagename'
-    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
-    sourceImageTag: '$(ImageVersion)'
-    repositoryName: 'ni-grafana'
-    pushTag: '$(ImageVersion)'
-    autoCreateRepository: true
+    repository: "963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana"
+    command: push
+    Dockerfile: Dockerfile
+    tags: |
+      $(ImageVersion)
+      latest
 
 - task: Bash@3
   displayName: Docker cleanup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,18 @@ steps:
     regionName: 'us-east-1'
     imageSource: 'imagename'
     sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
+    sourceImageTag: '$(ImageVersion)'
+    repositoryName: 'ni-grafana'
+    pushTag: '$(ImageVersion)'
+    autoCreateRepository: true
+
+- task: ECRPushImage@1
+  displayName: Push docker image
+  inputs:
+    awsCredentials: 'AWS SystemLink Cloud'
+    regionName: 'us-east-1'
+    imageSource: 'imagename'
+    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
     sourceImageTag: 'latest'
     repositoryName: 'ni-grafana'
     pushTag: 'latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,14 @@ steps:
       echo "##vso[task.setvariable variable=ImageVersion;]$ImageVersion"
       # ImageVersion will look like "8.3.6-8a2963c-ni"
 
+  # Login to Docker Hub
+- task: Docker@2
+  displayName: Login to Docker Hub
+  inputs:
+    command: login
+    containerRegistry: DockerHub
+
+#---------------------------
 - task: Docker@2
   displayName: Build docker image
   inputs:
@@ -28,34 +36,23 @@ steps:
       $(ImageVersion)
       latest
 
-- task: ECRPushImage@1
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
-  displayName: Push docker image with versioned tag
+# Logout of Docker Hub
+- task: Docker@2
+  displayName: Log out of Docker Hub
   inputs:
-    awsCredentials: 'AWS SystemLink Cloud'
-    regionName: 'us-east-1'
-    imageSource: 'imagename'
-    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
-    sourceImageTag: '$(ImageVersion)'
-    repositoryName: 'ni-grafana'
-    pushTag: '$(ImageVersion)'
-    autoCreateRepository: true
+    command: logout
+    containerRegistry: DockerHub
 
-# ECRPushImage does not support specifying multiple tags at push time. We therefore push a second time to
-# additionally tag the image with the 'latest' tag. Note that this does not create a second image, and
-# this push completes very quickly since it just adds an additional tag to the image.
-- task: ECRPushImage@1
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
-  displayName: Tag image with latest
+#---------------------------
+- task: Docker@2
+  displayName: Push docker image
   inputs:
-    awsCredentials: 'AWS SystemLink Cloud'
-    regionName: 'us-east-1'
-    imageSource: 'imagename'
-    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
-    sourceImageTag: 'latest'
-    repositoryName: 'ni-grafana'
-    pushTag: 'latest'
-    autoCreateRepository: true
+    repository: "963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana"
+    command: push
+    Dockerfile: Dockerfile
+    tags: |
+      $(ImageVersion)
+      latest
 
 - task: Bash@3
   displayName: Docker cleanup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ steps:
       latest
 
 - task: Docker@2
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
   displayName: Push docker image
   inputs:
     repository: "963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,14 +18,6 @@ steps:
       echo "##vso[task.setvariable variable=ImageVersion;]$ImageVersion"
       # ImageVersion will look like "8.3.6-8a2963c-ni"
 
-  # Login to Docker Hub
-- task: Docker@2
-  displayName: Login to Docker Hub
-  inputs:
-    command: login
-    containerRegistry: DockerHub
-
-#---------------------------
 - task: Docker@2
   displayName: Build docker image
   inputs:
@@ -36,23 +28,34 @@ steps:
       $(ImageVersion)
       latest
 
-# Logout of Docker Hub
-- task: Docker@2
-  displayName: Log out of Docker Hub
+- task: ECRPushImage@1
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
+  displayName: Push docker image with versioned tag
   inputs:
-    command: logout
-    containerRegistry: DockerHub
+    awsCredentials: 'AWS SystemLink Cloud'
+    regionName: 'us-east-1'
+    imageSource: 'imagename'
+    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
+    sourceImageTag: '$(ImageVersion)'
+    repositoryName: 'ni-grafana'
+    pushTag: '$(ImageVersion)'
+    autoCreateRepository: true
 
-#---------------------------
-- task: Docker@2
-  displayName: Push docker image
+# ECRPushImage does not support specifying multiple tags at push time. We therefore push a second time to
+# additionally tag the image with the 'latest' tag. Note that this does not create a second image, and
+# this push completes very quickly since it just adds an additional tag to the image.
+- task: ECRPushImage@1
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
+  displayName: Tag image with latest
   inputs:
-    repository: "963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana"
-    command: push
-    Dockerfile: Dockerfile
-    tags: |
-      $(ImageVersion)
-      latest
+    awsCredentials: 'AWS SystemLink Cloud'
+    regionName: 'us-east-1'
+    imageSource: 'imagename'
+    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
+    sourceImageTag: 'latest'
+    repositoryName: 'ni-grafana'
+    pushTag: 'latest'
+    autoCreateRepository: true
 
 - task: Bash@3
   displayName: Docker cleanup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,9 @@ steps:
     pushTag: '$(ImageVersion)'
     autoCreateRepository: true
 
-# Push a second time to additionally tag the image with the 'latest' tag (the second push is instantaneous)
+# ECRPushImage does not support specifying multiple tags at push time. We therefore push a second time to
+# additionally tag the image with the 'latest' tag. Note that this does not create a second image, and
+# this push completes very quickly since it just adds an additional tag to the image.
 - task: ECRPushImage@1
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/ni/current'))
   displayName: Tag image with latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,18 +35,6 @@ steps:
     regionName: 'us-east-1'
     imageSource: 'imagename'
     sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
-    sourceImageTag: '$(ImageVersion)'
-    repositoryName: 'ni-grafana'
-    pushTag: '$(ImageVersion)'
-    autoCreateRepository: true
-
-- task: ECRPushImage@1
-  displayName: Push docker image
-  inputs:
-    awsCredentials: 'AWS SystemLink Cloud'
-    regionName: 'us-east-1'
-    imageSource: 'imagename'
-    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
     sourceImageTag: 'latest'
     repositoryName: 'ni-grafana'
     pushTag: 'latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,15 +28,29 @@ steps:
       $(ImageVersion)
       latest
 
-- task: Docker@2
+- task: ECRPushImage@1
   displayName: Push docker image
   inputs:
-    repository: "963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana"
-    command: push
-    Dockerfile: Dockerfile
-    tags: |
-      $(ImageVersion)
-      latest
+    awsCredentials: 'AWS SystemLink Cloud'
+    regionName: 'us-east-1'
+    imageSource: 'imagename'
+    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
+    sourceImageTag: '$(ImageVersion)'
+    repositoryName: 'ni-grafana'
+    pushTag: '$(ImageVersion)'
+    autoCreateRepository: true
+
+- task: ECRPushImage@1
+  displayName: Push docker image
+  inputs:
+    awsCredentials: 'AWS SystemLink Cloud'
+    regionName: 'us-east-1'
+    imageSource: 'imagename'
+    sourceImageName: '963234657927.dkr.ecr.us-east-1.amazonaws.com/ni-grafana'
+    sourceImageTag: 'latest'
+    repositoryName: 'ni-grafana'
+    pushTag: 'latest'
+    autoCreateRepository: true
 
 - task: Bash@3
   displayName: Docker cleanup


### PR DESCRIPTION
**What this PR does / why we need it**:
To facilitate automatically deploying new versions of our fork to `enterprise-dev`, we need to additionally tag our docker images with `latest`. When shipping a release to customers, we'll use the versioned tag that includes the commit hash. When deploying to `enterprise-dev`, we'll just use `latest`.

**Special notes for your reviewer**:
The `ECRPushImage` task only supports specifying one tag, so we need to push twice to add both tags. This seems to be the only way to push multiple tags to an image. This does not create multiple images.

Note that our other pipelines use the `Docker@2` task, which does support specifying multiple tags when pushing. I tried to use that task here, but I ran into permission problems. I assume that's why this GitHub pipeline was already using the `ECRPushImage` task.

Verified that both tags show up on ECR (I deleted the test image afterwards):
![image](https://user-images.githubusercontent.com/4745977/154873168-801bd100-d808-40f6-8599-3c5c262b6935.png)

Note also that the second push completes almost instantly:
![image](https://user-images.githubusercontent.com/4745977/154873195-374adf64-1d2f-4159-8256-e85b1491554c.png)
