### PR TITLE
Add "iframeNavigate" postMessage calls

### DIFF
--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -16,12 +16,16 @@ export class GrafanaRoute extends React.Component<Props> {
     keybindingSrv.initGlobals();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Mounted', this.props.match);
+    // TODO: Wrap this in a conditional that checks the config value "allow_embedding"
+    window.parent.postMessage('iframeNavigate', window.parent.location.origin);
   }
 
   componentDidUpdate(prevProps: Props) {
     this.cleanupDOM();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', this.props, prevProps);
+    // TODO: Wrap this in a conditional that checks the config value "allow_embedding"
+    window.parent.postMessage('iframeNavigate', window.parent.location.origin);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `postMessage` calls needed for route syncing when hosted in an iframe.

**Which issue(s) this PR fixes**:

https://ni.visualstudio.com/DefaultCollection/DevCentral/_workitems/edit/1821058

**Special notes for your reviewer**:

This is used by the `iframe-host` component added as part of the following PR:
https://ni.visualstudio.com/DevCentral/_git/Skyline/pullrequest/267998?path=/Web/Workspaces/Grafana/src/app/app.module.ts

Moved these changes to an `ni/pub/*` branch so we can attempt to upstream once we get the TODO figured out.