### PR TITLE
Docker: Replace openssl with openssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata musl-utils
-RUN apk add --no-cache openssl ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache openssl3 ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk upgrade ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk info -vv | sort
 


### PR DESCRIPTION
XRay has found a vulnerability in openssl 1.1.1 described in [this bug report](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17173).

According to the report generated by Xray, the fix is available in openssl3. According to [this wiki](https://wiki.openssl.org/index.php/OpenSSL_3.0#Main_Changes_in_OpenSSL_3.0_from_OpenSSL_1.1.1), upgrading apparently should be pretty straight-forward.


**Special notes for your reviewer**:

How should I test this? 