### PR TITLE
Run bash script to generate version number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Generate version number
         id: generate_version_number_step
-        run: tag_number=$(git describe --abbrev=0 --tags)
-             short_hash=$(git rev-parse --short ${{ github.sha }})
-             image_version="$(tag_number)-$(short_hash)-ni"
-             echo ::set-output name=image_version::$(echo $image_version)
-             # image_version will look like "8.3.6-8a2963c-ni"
+        run: |
+          tag_number=$(git describe --abbrev=0 --tags)
+          short_hash=$(git rev-parse --short ${{ github.sha }})
+          image_version="$(tag_number)-$(short_hash)-ni"
+          echo "::set-output name=image_version::$(echo $image_version)"
+        # image_version will look like "8.3.6-8a2963c-ni"
 
   build_docker_image:
     name: Build Docker Image


### PR DESCRIPTION
Fix the generate_version_number step in the build pipeline to execute a multi-line bash script.