### PR TITLE
Disable NavBarToggle

### DIFF
--- a/public/app/core/components/NavBar/NavBar.tsx
+++ b/public/app/core/components/NavBar/NavBar.tsx
@@ -101,14 +101,14 @@ export const NavBar = React.memo(() => {
               <Icon name="bars" size="xl" />
             </div>
 
-            <NavBarToggle
+            {/* <NavBarToggle
               className={styles.menuExpandIcon}
               isExpanded={menuOpen}
               onClick={() => {
                 reportInteraction('grafana_navigation_expanded');
                 setMenuOpen(true);
               }}
-            />
+            /> */}
 
             <NavBarMenuPortalContainer />
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9257800/186250453-d49049e5-6c23-4565-8b29-cf10f77ffaec.png)

The Nav Bar slideout is exposing a broken Grafana icon that we've removed. The slideout doesn't add much value, and it visually conflicts with the SystemLink header, so the easiest solution is to just remove the toggle entirely.

I built this locally and verified that the toggle is now hidden.