### PR TITLE
Update go version to 1.17.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.17.12-alpine3.15 as go-builder
+FROM golang:1.17.13-alpine3.15 as go-builder
 
 RUN apk add --no-cache gcc g++ make
 


### PR DESCRIPTION
Addresses [CVE-2022-32189](https://nvd.nist.gov/vuln/detail/CVE-2022-32189)