### PR TITLE
Fork branding updates for 9.4.1 base version

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -263,7 +263,7 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
       white-space: nowrap;
     `,
     utc: css`
-      color: ${theme.v1.palette.orange};
+      color: ${theme.v1.palette.niGreenLight};
       font-size: ${theme.typography.size.sm};
       padding-left: 6px;
       line-height: 28px;

--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -403,4 +403,8 @@ $vertical-resize-handle-dots-hover: $gray-2;
 // Calendar
 $calendar-bg-days: $input-bg;
 $calendar-bg-now: $dark-10;
+
+// NI Colors
+$ni-green-light: ${theme.v1.palette.niGreenLight};
+$ni-green-dark: ${theme.v1.palette.niGreenDark};
 `;

--- a/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
@@ -403,4 +403,7 @@ $vertical-resize-handle-dots-hover: $gray-2;
 $calendar-bg-days: $white;
 $calendar-bg-now: $gray-6;
 
+// NI Colors
+$ni-green-light: ${theme.v1.palette.niGreenLight};
+$ni-green-dark: ${theme.v1.palette.niGreenDark};
 `;

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -17,13 +17,14 @@ func (s *ServiceImpl) getOrgAdminNode(c *contextmodel.ReqContext) (*navtree.NavL
 
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	if hasAccess(ac.ReqOrgAdmin, datasources.ConfigurationPageAccess) {
-		configNodes = append(configNodes, &navtree.NavLink{
-			Text:     "Data sources",
-			Icon:     "database",
-			SubTitle: "Add and configure data sources",
-			Id:       "datasources",
-			Url:      s.cfg.AppSubURL + "/datasources",
-		})
+		// Fork: Remove data source configuration page, which shows up for all users when viewers_can_edit = true.
+		// configNodes = append(configNodes, &navtree.NavLink{
+		// 	Text:     "Data sources",
+		// 	Icon:     "database",
+		// 	SubTitle: "Add and configure data sources",
+		// 	Id:       "datasources",
+		// 	Url:      s.cfg.AppSubURL + "/datasources",
+		// })
 	}
 
 	if s.features.IsEnabled(featuremgmt.FlagCorrelations) && hasAccess(ac.ReqOrgAdmin, correlations.ConfigurationPageAccess) {

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -77,7 +77,8 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   };
 
   onCopyShortLink = async () => {
-    await createAndCopyShortLink(window.location.href);
+    // Fork: correct link in iframe
+    await createAndCopyShortLink(window.parent.location.href);
     reportInteraction('grafana_explore_shortened_link_clicked');
   };
 

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -168,7 +168,7 @@ class UnthemedDashboardImport extends PureComponent<Props> {
 
   pageNav: NavModelItem = {
     text: 'Import dashboard',
-    subTitle: 'Import dashboard from file or Grafana.com',
+    subTitle: 'Import dashboard from file',
     breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
   };
 

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -112,9 +112,8 @@ $text-shadow-faint: 1px 1px 4px rgb(45, 45, 45);
 $textShadow: none;
 
 // gradients
-// Fork: NI-specific colors
-$brand-gradient-horizontal: linear-gradient(to right, #009B65 30%, #26A97C 99%);
-$brand-gradient-vertical: linear-gradient(#009B65 30%, #26A97C 99%);
+$brand-gradient-horizontal: linear-gradient(270deg, #F55F3E 0%, #FF8833 100%);
+$brand-gradient-vertical: linear-gradient(0.01deg, #F55F3E 0.01%, #FF8833 99.99%);
 
 // Links
 // -------------------------
@@ -406,3 +405,7 @@ $vertical-resize-handle-dots-hover: $gray-2;
 // Calendar
 $calendar-bg-days: $input-bg;
 $calendar-bg-now: $dark-10;
+
+// NI Colors
+$ni-green-light: #26A97C;
+$ni-green-dark: #009B65;

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -107,9 +107,8 @@ $text-blue: #1F62E0;
 $text-shadow-faint: none;
 
 // gradients
-// Fork: NI-specific colors
-$brand-gradient-horizontal: linear-gradient(to right, #009B65 30%, #26A97C 99%);
-$brand-gradient-vertical: linear-gradient(#009B65 30%, #26A97C 99%);
+$brand-gradient-horizontal: linear-gradient(90deg, #26A97C 0%, #009B65 100%);;
+$brand-gradient-vertical: linear-gradient(0.01deg, #009B65 -31.2%, #26A97C 113.07%);;
 
 // Links
 // -------------------------
@@ -404,3 +403,6 @@ $vertical-resize-handle-dots-hover: $gray-2;
 $calendar-bg-days: $white;
 $calendar-bg-now: $gray-6;
 
+// NI Colors
+$ni-green-light: #26A97C;
+$ni-green-dark: #009B65;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -1,7 +1,7 @@
 .explore-active-button {
   box-shadow: $btn-active-box-shadow;
-  border: 1px solid $orange-dark !important;
-  color: $orange-dark !important;
+  border: 1px solid $ni-green-dark !important;
+  color: $ni-green-dark !important;
 }
 
 // TODO: this is used in Loki & Prometheus, move it


### PR DESCRIPTION
Changes:
- Explore toolbar buttons - green highlight instead of orange
- Remove mention of "Grafana.com" in import page
- Fixes incorrect path for Explore shortened link
- Green instead of orange text when hovering over time range picker