### PR TITLE
Disable Explore short link

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -77,8 +77,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   };
 
   onCopyShortLink = async () => {
-    // Fork: correct link in iframe
-    await createAndCopyShortLink(window.parent.location.href);
+    await createAndCopyShortLink(window.location.href);
     reportInteraction('grafana_explore_shortened_link_clicked');
   };
 
@@ -270,7 +269,8 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
 
     const toolbarLeftItems = [
       // We only want to show the shortened link button in the left Toolbar if topnav is not enabled as with topnav enabled it sits next to the brecrumbs
-      !isTopnav && exploreId === ExploreId.left && shareButton,
+      // Fork: disable short link button
+      // !isTopnav && exploreId === ExploreId.left && shareButton,
       getDataSourcePicker(),
     ].filter(Boolean);
 


### PR DESCRIPTION
In #42, I unsuccessfully attempted to fix the share link path for the Explore view. The generated link comes from the backend, so it's not as straightforward to fix as I thought because the server doesn't know about the /dashboards path. I just decided to disable the button for now. We already have short links disabled for dashboards, so we can revisit them both in the future if desired.