### PR TITLE
Hide "General" folder option when saving dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Removal of kiosk mode
 - Removal of plugins list plugin
 - Removal of snapshot functionality
+- Hiding the "General" folder
 
 ---
 

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -71,7 +71,7 @@ export function FolderPicker(props: Props) {
     initialTitle = '',
     permissionLevel = PermissionLevelString.Edit,
     rootName = 'General',
-    showRoot = true,
+    showRoot = false,
     skipInitialLoad,
     accessControlMetadata,
     customAdd,
@@ -135,7 +135,6 @@ export function FolderPicker(props: Props) {
 
   const loadInitialValue = async () => {
     const resetFolder: SelectableValue<string> = { label: initialTitle, value: undefined };
-    const rootFolder: SelectableValue<string> = { label: rootName, value: '' };
 
     const options = await getOptions('');
 
@@ -150,16 +149,12 @@ export function FolderPicker(props: Props) {
     }
 
     if (!folder && !allowEmpty) {
-      if (contextSrv.isEditor) {
-        folder = rootFolder;
+      // We shouldn't assign a random folder without the user actively choosing it on a persisted dashboard
+      const isPersistedDashBoard = !!dashboardId;
+      if (isPersistedDashBoard) {
+        folder = resetFolder;
       } else {
-        // We shouldn't assign a random folder without the user actively choosing it on a persisted dashboard
-        const isPersistedDashBoard = !!dashboardId;
-        if (isPersistedDashBoard) {
-          folder = resetFolder;
-        } else {
-          folder = options.length > 0 ? options[0] : resetFolder;
-        }
+        folder = options.find((option) => option.label === 'Default') ?? options[0] ?? resetFolder;
       }
     }
     !isCreatingNew && setFolder(folder);


### PR DESCRIPTION
https://dev.azure.com/ni/DevCentral/_workitems/edit/2325767

The "General" folder is special in Grafana and is the default folder in which to save dashboards. This is problematic for our usage, as our users only have permissions to save dashboards to folders corresponding with workspaces. i.e. they will never have access to the General folder. This change is a front-end bandaid that both hides the General folder as an option in the folder picker dropdown and changes the initially selected folder. It will now pick a folder titled "Default" (if it exists) or the first available folder that the user has access to. 