### PR TITLE
Allow unsigned nested plugins if parent is allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Removal of plugins list plugin
 - Removal of snapshot functionality
 - Hiding the "General" folder
+- Allow unsigned nested plugins if parent is allowed
 
 ---
 

--- a/pkg/plugins/manager/signature/authorizer.go
+++ b/pkg/plugins/manager/signature/authorizer.go
@@ -34,6 +34,7 @@ func (u *UnsignedPluginAuthorizer) CanLoadPlugin(p *plugins.Plugin) bool {
 		}
 	}
 
+	// Allow a plugin to be unsigned when nested in an whitelisted app plugin
 	if p.Parent != nil {
 		for _, pID := range u.cfg.PluginsAllowUnsigned {
 			if pID == p.Parent.ID {

--- a/pkg/plugins/manager/signature/authorizer.go
+++ b/pkg/plugins/manager/signature/authorizer.go
@@ -34,5 +34,13 @@ func (u *UnsignedPluginAuthorizer) CanLoadPlugin(p *plugins.Plugin) bool {
 		}
 	}
 
+	if p.Parent != nil {
+		for _, pID := range u.cfg.PluginsAllowUnsigned {
+			if pID == p.Parent.ID {
+				return true
+			}
+		}
+	}
+
 	return false
 }


### PR DESCRIPTION
We're migrating our plugins to be nested in an app plugin: https://grafana.github.io/plugin-tools/docs/nested-plugins
Unsigned plugins (which is what our plugins are) have to be explicitly whitelisted to be loaded in the UI. It would simplify our helm charts if we only had to whitelist the app plugin itself and it would apply to all of its nested plugins. This is what this change does.
