### PR TITLE
Revert change to use parent window href when generating dashboard links

### DIFF
--- a/.github/workflows/detect-breaking-changes-build-skip.yml
+++ b/.github/workflows/detect-breaking-changes-build-skip.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Upload artifact (so it can be used in the more privileged "report" workflow)
       - name: Upload check output as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: levitate
           path: levitate/

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -30,19 +30,6 @@ export const DashboardLinks = ({ dashboard, links }: Props) => {
     return null;
   }
 
-  // NI fork: Use iframe location for links
-  const getCorrectedHref = function (href: string) {
-    try {
-      // If absolute URL, return
-      new URL(href);
-      return href;
-    } catch {
-      // If relative URL, build in context of iframe location
-      const split = window.parent.location.href.split('/d/');
-      return `${split[0]}/${href}`;
-    }
-  };
-
   return (
     <>
       {links.map((link: DashboardLink, index: number) => {
@@ -57,7 +44,7 @@ export const DashboardLinks = ({ dashboard, links }: Props) => {
 
         const linkElement = (
           <DashboardLinkButton
-            href={getCorrectedHref(sanitizeUrl(linkInfo.href))}
+            href={sanitizeUrl(linkInfo.href)}
             target={link.targetBlank ? '_blank' : undefined}
             rel="noreferrer"
             data-testid={selectors.components.DashboardLinks.link}

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -24,20 +24,6 @@ interface DashboardLinksMenuProps {
   dashboardUID: string;
 }
 
-// NI fork: Use iframe location for links
-function getCorrectedHref(href: string) {
-  try {
-    // If absolute URL, return
-    new URL(href);
-    return href;
-  } catch {
-    // If relative URL, build in context of iframe location
-    const splitParent = window.parent.location.href.split('/d/');
-    const splitLink = href.split('/d/');
-    return `${splitParent[0]}/d/${splitLink[1]}`;
-  }
-};
-
 function DashboardLinksMenu({ dashboardUID, link }: DashboardLinksMenuProps) {
   const styles = useStyles2(getStyles);
   const resolvedLinks = useResolvedLinks({ dashboardUID, link });
@@ -53,7 +39,7 @@ function DashboardLinksMenu({ dashboardUID, link }: DashboardLinksMenuProps) {
           {resolvedLinks.map((resolvedLink, index) => {
             return (
               <Menu.Item
-                url={getCorrectedHref(resolvedLink.url)}
+                url={resolvedLink.url}
                 target={link.targetBlank ? '_blank' : undefined}
                 key={`dashlinks-dropdown-item-${resolvedLink.uid}-${index}`}
                 label={resolvedLink.title}
@@ -102,7 +88,7 @@ export const DashboardLinksDashboard = (props: Props) => {
               icon="apps"
               variant="secondary"
               fill="outline"
-              href={getCorrectedHref(resolvedLink.url)}
+              href={resolvedLink.url}
               target={link.targetBlank ? '_blank' : undefined}
               rel="noreferrer"
               data-testid={selectors.components.DashboardLinks.link}


### PR DESCRIPTION
Revert most of the changes from https://github.com/ni/grafana/commit/fb2106368f682fdad8608e2d18d574b92dd14944, which modified links to dashboards to be URLs for SLE rather than URLs for grafana. The unintended consequence of the previous change is that clicking on those links within SLE causes a nested SLE frame within the iframe containing grafana.

I did not revert the change made to the `ShareModal` utils in that commit: https://github.com/ni/grafana/commit/fb2106368f682fdad8608e2d18d574b92dd14944#diff-d58ef3e7e6eae57dba22ca9dbddd953bae59b59727f5e240752682f9c84ffe66R59. This is because, from what I can tell, that utility function isn't used to generate a URL that will be used on a button or hyperlink that can be clicked within the product. Instead, it is used to generate a URL that you can copy if you want to share a dashboard. Therefore, it seemed valid to leave that link generation using the parent window's href. 