### PR TITLE
Ensure grafana is always loaded within the SLE iframe

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -51,16 +51,8 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     await loadAndInitAngularIfEnabled();
     this.setState({ ready: true });
     $('.preloader').remove();
-
-    // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
-    if (window.self === window.top && window.location.hostname !== 'localhost') {
-      // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
-      let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
-      window.location.replace(newHref);
-    } else {
-      // Tell the iframe-host loading indicator to disappear
-      window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
-    }
+    // NI fork: Tells iframe-host loading indicator when to disappear
+    window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
   }
 
   renderRoute = (route: RouteDescriptor) => {

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -51,8 +51,16 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     await loadAndInitAngularIfEnabled();
     this.setState({ ready: true });
     $('.preloader').remove();
-    // NI fork: Tells iframe-host loading indicator when to disappear
-    window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
+
+    // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
+    if (window.self === window.top && window.location.hostname !== 'localhost') {
+      // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
+      let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
+      window.location.replace(newHref);
+    } else {
+      // Tell the iframe-host loading indicator to disappear
+      window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
+    }
   }
 
   renderRoute = (route: RouteDescriptor) => {

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -17,7 +17,7 @@
     <script nonce="[[.Nonce]]">
       // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
       if (window.self === window.top && window.location.hostname !== 'localhost') {
-        if (!location.href.startsWith(location.origin + '/dashboardhost')) {
+        if (!window.location.href.startsWith(window.location.origin + '/dashboardhost')) {
           console.log('Unexpected location found outside of an iframe. Expected to be hosted at "/dashboardhost"');
         } else {
           // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -14,7 +14,7 @@
 
     <base href="[[.AppSubUrl]]/" />
 
-    <script>
+    <script nonce="[[.Nonce]]">
       // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
       if (window.self === window.top && window.location.hostname !== 'localhost') {
         // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -14,6 +14,15 @@
 
     <base href="[[.AppSubUrl]]/" />
 
+    <script>
+      // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
+      if (window.self === window.top && window.location.hostname !== 'localhost') {
+        // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
+        let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
+        window.location.replace(newHref);
+      }
+    </script>
+
     <link rel="icon" type="image/png" href="[[.FavIcon]]" />
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
     <link rel="mask-icon" href="[[.ContentDeliveryURL]]public/img/grafana_mask_icon.svg" color="#F05A28" />
@@ -274,16 +283,8 @@
         var preloader = document.getElementsByClassName("preloader");
         if (preloader.length) {
           preloader[0].className = "preloader preloader--done";
-
-          // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
-          if (window.self === window.top && window.location.hostname !== 'localhost') {
-            // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
-            let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
-            window.location.replace(newHref);
-          } else {
-            // Tell the iframe-host loading indicator to disappear
-            window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
-          }
+          // NI fork: Tells iframe-host loading indicator when to disappear
+          window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
         }
       }
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -274,8 +274,16 @@
         var preloader = document.getElementsByClassName("preloader");
         if (preloader.length) {
           preloader[0].className = "preloader preloader--done";
-          // NI fork: Tells iframe-host loading indicator when to disappear
-          window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
+
+          // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
+          if (window.self === window.top && window.location.hostname !== 'localhost') {
+            // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
+            let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
+            window.location.replace(newHref);
+          } else {
+            // Tell the iframe-host loading indicator to disappear
+            window.parent.postMessage({ type: 'iframeLoaded' }, window.parent.location.origin);
+          }
         }
       }
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -17,9 +17,13 @@
     <script nonce="[[.Nonce]]">
       // NI fork: Ensure that grafana is loaded within an iframe unless it is running locally
       if (window.self === window.top && window.location.hostname !== 'localhost') {
-        // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
-        let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
-        window.location.replace(newHref);
+        if (!location.href.startsWith(location.origin + '/dashboardhost')) {
+          console.log('Unexpected location found outside of an iframe. Expected to be hosted at "/dashboardhost"');
+        } else {
+          // Redirect to the iframe-hosted version of grafana, which is located at /dashboards rather than /dashboardhost
+          let newHref = window.location.href.replace(window.location.origin + '/dashboardhost', window.location.origin + '/dashboards');
+          window.location.replace(newHref);
+        }
       }
     </script>
 


### PR DESCRIPTION
In multiple places throughout grafana, it's possible to link between dashboards. With the way that grafana is hosted in an iframe within SLE, this poses some problems. The issue stems from the fact that grafana itself is hosted under the `/dashboardhost` route while the grafana Angular app that hosts the iframe is hosted under `/dashboards`. As a result, we run into the following problem:

- Links opening within the same tab need to use the `/dashboardhost` route to avoid navigating the iframe to SLE, which results in nested SLE frames
- Links opening in a new tab/window (including copy & pasted to a new person or browser) need to use the `/dashboard` route to avoid navigating to grafana hosted outside of the SLE frame
- We can't know how a given link will be used, especially given standard link behaviors in browsers such as "Open link in new tab" or "Copy link" in the right-click menu

Because we can't know how a given link that's generated will be opened, the best solution is to allow grafana to generate links as though it were not hosted in an iframe (i.e. using `/dashboardhost`) but ensure that if grafana is loaded outside of the SLE frame, we automatically redirect the user to SLE. This is accomplished by redirecting from `/dashboardhost` to `/dashboards` in the case that grafana is not loaded in an iframe (determined by comparing `window.self` to `window.top`). The exception to this is when grafana is running on `localhost` so that grafana can still be run locally without it being hosted in the Angular app.