### PR TITLE
Remove pvallone from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cameronwaterman
+* @cameronwaterman @atmgrifter00 @rajsite

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pvallone @cameronwaterman
+* @cameronwaterman


### PR DESCRIPTION
With the ownership changes, it doesn't make sense for me to review changes to our fork of Grafana anymore. Cameron is sufficient.