### PR TITLE
Handling changes for grafana 11

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/splitBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/splitBy.test.ts
@@ -3,7 +3,6 @@ import { DataTransformerConfig } from '@grafana/data';
 import { toDataFrame } from '../../dataframe/processDataFrame';
 import { FieldType } from '../../types';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
-import { ArrayVector } from '../../vector';
 import { transformDataFrame } from '../transformDataFrame';
 
 import { DataTransformerID } from './ids';
@@ -96,13 +95,13 @@ describe('SplitBy transformer', () => {
               {
                 name: 'time',
                 type: FieldType.time,
-                values: new ArrayVector([3000]),
+                values: [3000],
                 config: {},
               },
               {
                 name: 'values',
                 type: FieldType.number,
-                values: new ArrayVector([1]),
+                values: [1],
                 config: { unit: 'm' },
               },
             ],
@@ -114,13 +113,13 @@ describe('SplitBy transformer', () => {
               {
                 name: 'time',
                 type: FieldType.time,
-                values: new ArrayVector([4000, 5000]),
+                values: [4000, 5000],
                 config: {},
               },
               {
                 name: 'values',
                 type: FieldType.number,
-                values: new ArrayVector([2, 2]),
+                values: [2, 2],
                 config: { unit: 'm' },
               },
             ],
@@ -132,13 +131,13 @@ describe('SplitBy transformer', () => {
               {
                 name: 'time',
                 type: FieldType.time,
-                values: new ArrayVector([6000, 7000, 8000]),
+                values: [6000, 7000, 8000],
                 config: {},
               },
               {
                 name: 'values',
                 type: FieldType.number,
-                values: new ArrayVector([3, 3, 3]),
+                values: [3, 3, 3],
                 config: { unit: 'm' },
               },
             ],

--- a/packages/grafana-data/src/transformations/transformers/splitBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/splitBy.ts
@@ -3,7 +3,6 @@ import { map } from 'rxjs/operators';
 
 import { DataFrame } from '../../types/dataFrame';
 import { SynchronousDataTransformerInfo } from '../../types/transformations';
-import { ArrayVector } from '../../vector/ArrayVector';
 import { fieldMatchers } from '../matchers';
 import { FieldMatcherID } from '../matchers/ids';
 
@@ -24,7 +23,7 @@ export const splitByTransformer: SynchronousDataTransformerInfo<SplitByTransform
     field: '',
   },
 
-  operator: (options, ctx) => (source) => 
+  operator: (options, ctx) => (source) =>
     source.pipe(map((data) => splitByTransformer.transformer(options, ctx)(data))),
 
   transformer: (options: SplitByTransformerOptions) => (data: DataFrame[]) => {
@@ -57,7 +56,7 @@ export const splitByTransformer: SynchronousDataTransformerInfo<SplitByTransform
         name: field.name,
         type: field.type,
         config: { ...field.config },
-        values: new ArrayVector(groups[group].map(ix => field.values.get(ix)))
+        values: groups[group].map(ix => field.values[ix])
       }))
     }));
 

--- a/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
@@ -43,7 +43,7 @@ export const EmptyState = ({
   children,
   image,
   message,
-  hideImage = false,
+  hideImage = true,
   variant,
   role,
 }: React.PropsWithChildren<Props>) => {

--- a/packages/grafana-ui/src/themes/GlobalStyles/queryEditor.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/queryEditor.ts
@@ -25,7 +25,7 @@ export function getQueryEditorStyles(theme: GrafanaTheme2) {
       },
     },
     '.query-segment-operator': {
-      color: #009b65 !important,
+      color: 'rgb(0, 155, 101) !important',
     },
     '.tight-form-func': {
       background: theme.colors.background.secondary,

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -81,9 +81,9 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	treeRoot := &navtree.NavTreeRoot{}
 
-	treeRoot.AddSection(s.getHomeNode(c, prefs))
+	//treeRoot.AddSection(s.getHomeNode(c, prefs))
 
-	if hasAccess(ac.EvalPermission(dashboards.ActionDashboardsRead)) {
+	if hasAccess(ac.EvalPermission(dashboards.ActionDashboardsRead)) && false {
 		starredItemsLinks, err := s.buildStarredItemsNavLinks(c)
 		if err != nil {
 			return nil, err
@@ -130,7 +130,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
-	if hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
+	if hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) && false {
 		drilldownChildNavLinks := s.buildDrilldownNavLinks(c)
 		treeRoot.AddSection(&navtree.NavLink{
 			Text:       "Drilldown",
@@ -144,12 +144,12 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
-	if s.cfg.ProfileEnabled && c.IsSignedIn {
+	if s.cfg.ProfileEnabled && c.IsSignedIn && false {
 		treeRoot.AddSection(s.getProfileNode(c))
 	}
 
 	_, uaIsDisabledForOrg := s.cfg.UnifiedAlerting.DisabledOrgs[c.SignedInUser.GetOrgID()]
-	uaVisibleForOrg := s.cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
+	uaVisibleForOrg := s.cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg && false
 
 	if uaVisibleForOrg {
 		if alertingSection := s.buildAlertNavLinks(c); alertingSection != nil {
@@ -163,7 +163,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	orgAdminNode, err := s.getAdminNode(c)
 
-	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
+	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 && false {
 		treeRoot.AddSection(orgAdminNode)
 	} else if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.RemoveSectionByID(navtree.NavIDCfg)
 	}
 
-	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagPinNavItems) && c.IsSignedIn {
+	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagPinNavItems) && c.IsSignedIn && false {
 		treeRoot.AddSection(&navtree.NavLink{
 			Text:           "Bookmarks",
 			Id:             navtree.NavIDBookmarks,

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -141,7 +141,7 @@ const getStyles = (theme: GrafanaTheme2, hasActions: boolean) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: hasActions ? TOP_BAR_LEVEL_HEIGHT * 2 : TOP_BAR_LEVEL_HEIGHT,
+      paddingTop: hasActions ? TOP_BAR_LEVEL_HEIGHT : 0,
       flexGrow: 1,
       height: 'auto',
     }),

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -64,9 +64,9 @@ export class AppChromeService {
         if (kioskMode || chromeless) {
           return 0;
         } else if (actions) {
-          return TOP_BAR_LEVEL_HEIGHT * 2;
-        } else {
           return TOP_BAR_LEVEL_HEIGHT;
+        } else {
+          return 0;
         }
       })
     )

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -37,9 +37,9 @@ export const MegaMenu = memo(
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
 
-    // Remove profile + help from tree
+    // Remove profile + help from tree (NI fork additionally removes Explore and Connections)
     const navItems = navTree
-      .filter((item) => item.id !== 'profile' && item.id !== 'help')
+      .filter((item) => item.id !== 'profile' && item.id !== 'help' && item.id !== 'explore' && item.id !== 'connections')
       .map((item) => enrichWithInteractionTracking(item, state.megaMenuDocked));
 
     if (config.featureToggles.pinNavItems) {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -1,12 +1,10 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconButton, Stack, ToolbarButton, useTheme2 } from '@grafana/ui';
+import { IconButton, Stack, useTheme2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { t } from 'app/core/internationalization';
 
-import { Branding } from '../../Branding/Branding';
-import { OrganizationSwitcher } from '../OrganizationSwitcher/OrganizationSwitcher';
 import { TOP_BAR_LEVEL_HEIGHT } from '../types';
 
 export interface Props {
@@ -27,17 +25,26 @@ export function MegaMenuHeader({ handleMegaMenu, handleDockedMenu, onClose }: Pr
   return (
     <div className={styles.header}>
       <Stack alignItems="center" minWidth={0} gap={0.25}>
-        <ToolbarButton
+        { // begin NI fork changes
+        <IconButton
+            onClick={handleMegaMenu}
+            tooltip={t('navigation.megamenu.close', 'Close menu')}
+            name='arrow-from-right'
+            style={{ transform: 'rotate(180deg)' }}
+          >
+        </IconButton>
+        /* <ToolbarButton
           narrow
           id={MEGA_MENU_HEADER_TOGGLE_ID}
           onClick={handleMegaMenu}
           tooltip={t('navigation.megamenu.close', 'Close menu')}
-        >
+                  >
           <Branding.MenuLogo className={styles.img} />
         </ToolbarButton>
-        <OrganizationSwitcher />
+        <OrganizationSwitcher /> */
+        }
       </Stack>
-      <IconButton
+      {/* <IconButton
         id={DOCK_MENU_BUTTON_ID}
         className={styles.dockMenuButton}
         tooltip={
@@ -56,7 +63,9 @@ export function MegaMenuHeader({ handleMegaMenu, handleDockedMenu, onClose }: Pr
         onClick={onClose}
         size="xl"
         variant="secondary"
-      />
+      /> */
+      // end NI fork changes
+    }
     </div>
   );
 }

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -3,7 +3,7 @@ import { cloneDeep } from 'lodash';
 import { memo } from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { Dropdown, Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { Dropdown, IconButton, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { contextSrv } from 'app/core/core';
@@ -11,7 +11,6 @@ import { t } from 'app/core/internationalization';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { useSelector } from 'app/types';
 
-import { Branding } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { HistoryContainer } from '../History/HistoryContainer';
@@ -52,27 +51,37 @@ export const SingleTopBar = memo(function SingleTopBar({
   const homeNav = useSelector((state) => state.navIndex)[HOME_NAV_ID];
   const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav, homeNav);
   const unifiedHistoryEnabled = config.featureToggles.unifiedHistory;
+  const hideBarStyle: React.CSSProperties = breadcrumbs.length > 1 ? { display: 'none' } : {};
 
   return (
-    <div className={styles.layout}>
+    <div className={styles.layout} style={hideBarStyle}>
       <Stack minWidth={0} gap={0.5} alignItems="center">
         {!menuDockedAndOpen && (
-          <ToolbarButton
-            narrow
+          // begin NI fork changes
+          <IconButton
             id={MEGA_MENU_TOGGLE_ID}
             onClick={onToggleMegaMenu}
             tooltip={t('navigation.megamenu.open', 'Open menu')}
+            name='arrow-from-right'
           >
-            <Stack gap={0} alignItems="center">
-              <Branding.MenuLogo className={styles.img} />
-              <Icon size="sm" name="angle-down" />
-            </Stack>
-          </ToolbarButton>
-        )}
+        </IconButton>
+        // <ToolbarButton
+        //     narrow
+        //     id={MEGA_MENU_TOGGLE_ID}
+        //     onClick={onToggleMegaMenu}
+        //     tooltip={t('navigation.megamenu.open', 'Open menu')}
+        //   >
+        //     <Stack gap={0} alignItems="center">
+        //       <Branding.MenuLogo className={styles.img} />
+        //       <Icon size="sm" name="angle-down" />
+        //     </Stack>
+        //   </ToolbarButton>
+        // end NI fork changes
+      )}
         <Breadcrumbs breadcrumbs={breadcrumbs} className={styles.breadcrumbsWrapper} />
       </Stack>
 
-      <Stack gap={0.5} alignItems="center">
+      <Stack gap={0.5} alignItems="center" style={{ display: 'none'}}>
         <TopSearchBarCommandPaletteTrigger />
         {unifiedHistoryEnabled && <HistoryContainer />}
         <QuickAdd />

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -85,7 +85,7 @@ export interface Props {
   hideEdition?: boolean;
 }
 
-export const Footer = React.memo(({ customLinks, hideEdition }: Props) => {
+export const Footer = memo(({ customLinks, hideEdition }: Props) => {
   const links = (customLinks || getFooterLinks());
   const styles = useStyles2(getStyles);
 

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -110,6 +110,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageInner: css({
       label: 'page-inner',
       padding: theme.spacing(2),
+      paddingTop: theme.spacing.x8, // NI fork changes
       borderBottom: 'none',
       background: theme.colors.background.primary,
       display: 'flex',
@@ -119,6 +120,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       [theme.breakpoints.up('md')]: {
         padding: theme.spacing(4),
+        paddingTop: theme.spacing.x8, // NI fork changes
       },
     }),
     canvasContent: css({

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -413,7 +413,7 @@ function getStyles(theme: GrafanaTheme2) {
       justifySelf: 'left',
     }),
     operator: css({
-      color: theme.v1.palette.orange,
+      color: 'rgb(0, 155, 101)',
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

This PR is just a means to review the changes that I will be introducing into main via a force push to get on to version 11 of Grafana.

**Why do we need this feature?**

Just attempting to stay on a recent version of Grafana.

**Which issue(s) does this PR fix?**:

Fixes #[2719488](https://dev.azure.com/ni/DevCentral/_workitems/edit/2719488)

**Special notes for your reviewer:**

Here are the visual updates that this PR introduces:

Old Dashboards Home:
![OldDashboardsHome](https://github.com/user-attachments/assets/1229f46e-1003-4ac9-8bc9-f58fb1550514)

New Dashboards Home:
![NewDashboardsHome](https://github.com/user-attachments/assets/7fb62a7e-c073-4e7e-b254-24807a3774ee)

Old Folder View:
![OldFolderView](https://github.com/user-attachments/assets/fef3ec66-8184-4b73-ac50-aaedf9551b9b)

New Folder View:
![NewFolderView](https://github.com/user-attachments/assets/702cd504-3929-4801-990c-b2ba16bdbf6e)

Old Dashboard Menu Open:
![OldDashboardMenuOpen](https://github.com/user-attachments/assets/82568c5d-6600-4dfc-b02b-5111b1afe2f8)

New Dashboard Menu Open:
![NewDashboardMenuOpen](https://github.com/user-attachments/assets/ebc33f18-8078-498c-a590-6d31fce1f33c)

Old Dashboard Page:
![OldDashboardPage](https://github.com/user-attachments/assets/2bbdf46d-717c-4339-8246-aa101817b7c6)

New Dashboard Page:
![NewDashboardPage](https://github.com/user-attachments/assets/d3fc4632-a45c-4bcc-9433-bb983932d5fa)

Old Explore Page:
![OldExplorePage](https://github.com/user-attachments/assets/4546b220-69fa-4c48-9e72-0c7c0c656dae)

New Explore Page:
![NewExplorePage](https://github.com/user-attachments/assets/3cd1a1a4-1a8e-462e-b74b-5809b0a5ce28)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
