### PR TITLE
Use absolute URL for checkbox image to avoid issue on Firefox

### DIFF
--- a/public/app/features/variables/pickers/shared/VariableOptions.tsx
+++ b/public/app/features/variables/pickers/shared/VariableOptions.tsx
@@ -137,7 +137,9 @@ class VariableOptions extends PureComponent<Props> {
 }
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => {
-  const checkboxImageUrl = theme.isDark ? 'public/img/checkbox.png' : 'public/img/checkbox_white.png';
+  const relativeCheckboxImageUrl = theme.isDark ? 'public/img/checkbox.png' : 'public/img/checkbox_white.png';
+  // NI fork: Use absolute URL to avoid issue with incorrect base path used when in an Emotion Global style in an iframe on Firefox
+  const checkboxImageUrl = `${document.baseURI}${relativeCheckboxImageUrl}`;
 
   return {
     hideVariableOptionIcon: css({


### PR DESCRIPTION
Fixes AzDO bug: https://dev.azure.com/ni/DevCentral/_workitems/edit/3207943

Previous commit did not fix the issue completely. It fixed the issue when loading fonts from the main Dashboards page, but not when loading the checkbox image upon opening a multi-select dropdown.

Using an absolute path avoids the issue, so now prepending the `document.baseURI` to the relative path.

STILL NECESSARY?
There's not a bulletproof way to tell if a new Grafana version obviates the need for this change. If you can run the validation described below without this change, then apparently we don't need it anymore.

VALIDATION:
1. Launch the Dashboards app in Firefox
2. Find/create a dashboard with a multi-option dropdown (e.g. asset selector), and ensure the checkbox images are loaded. There shouldn't be any 404 error in the devtools network tab for the checkbox image fetch.