### PR TITLE
Doc updates for architecture overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+**Attention: This is a fork of [Grafana](https://github.com/grafana/grafana) for use in the NI SystemLink™ platform.**
+
+See the NI-specific contribution docs in [`CONTRIBUTING_NI.md`](./CONTRIBUTING_NI.md).
+
+---
+
 # Contributing to Grafana
 
 Thank you for your interest in contributing to Grafana! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING_NI.md
+++ b/CONTRIBUTING_NI.md
@@ -74,6 +74,10 @@ Once the cherry pick is completed, force push main (`git push -f`). If you are n
 
 If you find you need to update `main` multiple times during the same release upgrade process (you may find issues that need resolution after initial attempt), or as part of the cherry-pick process you inadvertently introduced new commits, you can/should collapse those commits into a single commit (the most recent commit) using `git rebase -i (commit before first new commit)`.
 
+#### Validate a new release of Grafana?
+
+See the validation instructions in the [`Skyline/Grafana README.md`](https://dev.azure.com/ni/DevCentral/_git/Skyline?path=/Grafana/README.MD&_a=preview).
+
 ### Security scanning with Snyk
 
 This repository uses [Snyk](https://snyk.io/) for security scanning to identify and fix vulnerabilities in code before they reach production. Snyk provides Static Application Security Testing (SAST) that scans your code for security issues as you develop.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 - Hiding the "General" folder
 - Allow unsigned nested plugins if parent is allowed
 
+See the NI-specific contribution docs in [`CONTRIBUTING_NI.md`](./CONTRIBUTING_NI.md).
+
+See an overview of the SystemLink Grafana integration in the [Dashboard Host Service runbook](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/91033/Dashboard-Host-Service-runbook).
+
 ---
 
 ![Grafana Logo (Light)](docs/logo-horizontal.png#gh-light-mode-only)


### PR DESCRIPTION
**What is this feature?**

Documentation updates to include links to the architecture overview pages. See [AZDO#2621694](https://dev.azure.com/ni/DevCentral/_workitems/edit/2621694).

Note: Some of the referenced pages will be updated to include the docs discussed, see details in the referenced issue.
