### PR TITLE
Update CODEOWNERS to grafana-codeowners-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @cameronwaterman @rajsite @m-akinc
+* @ni/grafana-codeowners-team
 
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick


### PR DESCRIPTION
Update general Grafana CODEOWNERS to the @ni/grafana-codeowners-team so adjustments to CODEOWNERS across Grafana repos is easier.