### PR TITLE
feat(kiosk): implement embed kiosk mode and update related functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Update of "home" dashboard to remove unwanted panels
 - Addition of link to this fork of Grafana
 - Modification of sharing and linking functionality to work when embedded
-- Removal of kiosk mode
+- Addition of custom `?kiosk=embed` mode that hides navigation, toolbar, variables, links, and panel menus while keeping time picker visible (Escape key does not exit this mode)
 - Removal of plugins list plugin
 - Removal of snapshot functionality
 - Hiding the "General" folder

--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -11,6 +11,8 @@ import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult, QueryResponse } from 'app/features/search/service/types';
 
+import { KioskMode } from 'app/types';
+
 import { Page } from '../Page/Page';
 
 import { AppChrome } from './AppChrome';
@@ -109,5 +111,18 @@ describe('AppChrome', () => {
     waitFor(() => {
       expect(screen.queryByRole('link', { name: 'Skip to main content' })).not.toBeInTheDocument();
     });
+  });
+
+  it('should hide mega menu button in embed kiosk mode but render page content', async () => {
+    const { context } = setup(<Page navId="child1">Children</Page>);
+    act(() => {
+      context.chrome.update({
+        kioskMode: KioskMode.Embed,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Open menu' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('page-children')).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -11,7 +11,7 @@ import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult, QueryResponse } from 'app/features/search/service/types';
 
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { Page } from '../Page/Page';
 

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -47,7 +47,16 @@ export function AppChrome({ children }: Props) {
   );
 
   const headerLevels = useChromeHeaderLevels();
-  const headerHeight = (headerLevels - 1) * getChromeHeaderLevelHeight();
+  // In embed kiosk mode the only rendered header row (SingleTopBarActions) is fully
+  // visible when present, so content must clear the full header height.
+  // useChromeHeaderLevels already accounts for whether actions exist in embed mode
+  // (returns 1 if actions present, 0 otherwise).
+  // On normal pages the NI-fork breadcrumb row is hidden via display:none, so we
+  // subtract one level instead.
+  const isKioskEmbed = state.kioskMode === KioskMode.Embed;
+  const headerHeight = isKioskEmbed
+    ? headerLevels * getChromeHeaderLevelHeight()
+    : (headerLevels - 1) * getChromeHeaderLevelHeight();
   const styles = useStyles2(getStyles, headerHeight);
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -11,7 +11,8 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import store from 'app/core/store';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
-import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
+import { ScopesDashboards, useScopesDashboardsState } from 'app/features/scopes';
+import { KioskMode } from 'app/types';
 
 import { AppChromeMenu } from './AppChromeMenu';
 import { AppChromeService, DOCKED_LOCAL_STORAGE_KEY } from './AppChromeService';
@@ -97,20 +98,19 @@ export function AppChrome({ children }: Props) {
           <LinkButton className={styles.skipLink} href="#pageContent">
             <Trans i18nKey="app-chrome.skip-content-button">Skip to main content</Trans>
           </LinkButton>
-          {menuDockedAndOpen && (
+          {menuDockedAndOpen && state.kioskMode !== KioskMode.Embed && (
             <MegaMenu className={styles.dockedMegaMenu} onClose={() => chrome.setMegaMenuOpen(false)} />
           )}
           <header className={cx(styles.topNav, menuDockedAndOpen && styles.topNavMenuDocked)}>
-            <SingleTopBar
-              sectionNav={state.sectionNav.node}
-              pageNav={state.pageNav}
-              onToggleMegaMenu={handleMegaMenu}
-              onToggleKioskMode={chrome.onToggleKioskMode}
-              actions={state.actions}
-              breadcrumbActions={state.breadcrumbActions}
-              scopes={scopes}
-              showToolbarLevel={headerLevels === 2}
-            />
+            {state.kioskMode !== KioskMode.Embed && (
+              <SingleTopBar
+                sectionNav={state.sectionNav.node}
+                pageNav={state.pageNav}
+                onToggleMegaMenu={handleMegaMenu}
+                onToggleKioskMode={chrome.onToggleKioskMode}
+              />
+            )}
+            {state.actions && <SingleTopBarActions>{state.actions}</SingleTopBarActions>}
           </header>
         </>
       )}
@@ -153,8 +153,8 @@ export function AppChrome({ children }: Props) {
           )}
         </div>
       </div>
-      {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
-      {!state.chromeless && <CommandPalette />}
+      {!state.chromeless && !state.megaMenuDocked && state.kioskMode !== KioskMode.Embed && <AppChromeMenu />}
+      {!state.chromeless && state.kioskMode !== KioskMode.Embed && <CommandPalette />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -11,8 +11,8 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import store from 'app/core/store';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
-import { ScopesDashboards, useScopesDashboardsState } from 'app/features/scopes';
-import { KioskMode } from 'app/types';
+import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
+import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeMenu } from './AppChromeMenu';
 import { AppChromeService, DOCKED_LOCAL_STORAGE_KEY } from './AppChromeService';
@@ -26,6 +26,7 @@ import { MegaMenu, MENU_WIDTH } from './MegaMenu/MegaMenu';
 import { useMegaMenuFocusHelper } from './MegaMenu/utils';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
 import { SingleTopBar } from './TopBar/SingleTopBar';
+import { SingleTopBarActions } from './TopBar/SingleTopBarActions';
 import { getChromeHeaderLevelHeight, useChromeHeaderLevels } from './TopBar/useChromeHeaderHeight';
 
 export interface Props extends PropsWithChildren<{}> {}
@@ -108,9 +109,19 @@ export function AppChrome({ children }: Props) {
                 pageNav={state.pageNav}
                 onToggleMegaMenu={handleMegaMenu}
                 onToggleKioskMode={chrome.onToggleKioskMode}
+                actions={state.actions}
+                breadcrumbActions={state.breadcrumbActions}
+                scopes={scopes}
+                showToolbarLevel={headerLevels === 2}
               />
             )}
-            {state.actions && <SingleTopBarActions>{state.actions}</SingleTopBarActions>}
+            {state.kioskMode === KioskMode.Embed && (state.actions || state.breadcrumbActions) && (
+              <SingleTopBarActions
+                actions={state.actions}
+                breadcrumbActions={state.breadcrumbActions}
+                scopes={scopes}
+              />
+            )}
           </header>
         </>
       )}

--- a/public/app/core/components/AppChrome/AppChromeService.test.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.test.tsx
@@ -1,3 +1,5 @@
+import { KioskMode } from 'app/types';
+
 import { AppChromeService } from './AppChromeService';
 
 describe('AppChromeService', () => {
@@ -37,5 +39,76 @@ describe('AppChromeService', () => {
       pageNav: { text: 'test', url: 'A', children: [{ text: 'child', active: true }] },
     });
     expect(stateChanges).toBe(4);
+  });
+
+  describe('setKioskModeFromUrl', () => {
+    it('should set Full kiosk mode for kiosk=1', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('1');
+      expect(chromeService.state.getValue().kioskMode).toBe(KioskMode.Full);
+    });
+
+    it('should set Full kiosk mode for kiosk=true', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl(true);
+      expect(chromeService.state.getValue().kioskMode).toBe(KioskMode.Full);
+    });
+
+    it('should set Embed kiosk mode for kiosk=embed', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('embed');
+      expect(chromeService.state.getValue().kioskMode).toBe(KioskMode.Embed);
+    });
+
+    it('should not set kiosk mode for invalid value', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('invalid');
+      expect(chromeService.state.getValue().kioskMode).toBeNull();
+    });
+
+    it('should set chromeless to true for Embed kiosk mode', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('embed');
+      expect(chromeService.state.getValue().chromeless).toBe(true);
+    });
+
+    it('should not set chromeless for null/undefined kiosk mode', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl(null);
+      expect(chromeService.state.getValue().kioskMode).toBeNull();
+    });
+
+    it('should set chromeless to true for Full kiosk mode', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('1');
+      expect(chromeService.state.getValue().chromeless).toBe(true);
+    });
+
+    it('should not change kioskMode when same value is set again', () => {
+      const chromeService = new AppChromeService();
+      chromeService.setKioskModeFromUrl('embed');
+      let stateChanges = 0;
+      chromeService.state.subscribe(() => stateChanges++);
+      chromeService.setKioskModeFromUrl('embed');
+      // Should not emit a new state since value hasn't changed
+      expect(stateChanges).toBe(1);
+    });
+  });
+
+  describe('getKioskUrlValue', () => {
+    it('should return true for Full kiosk mode', () => {
+      const chromeService = new AppChromeService();
+      expect(chromeService.getKioskUrlValue(KioskMode.Full)).toBe(true);
+    });
+
+    it('should return embed for Embed kiosk mode', () => {
+      const chromeService = new AppChromeService();
+      expect(chromeService.getKioskUrlValue(KioskMode.Embed)).toBe('embed');
+    });
+
+    it('should return null for null mode', () => {
+      const chromeService = new AppChromeService();
+      expect(chromeService.getKioskUrlValue(null)).toBeNull();
+    });
   });
 });

--- a/public/app/core/components/AppChrome/AppChromeService.test.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.test.tsx
@@ -1,4 +1,4 @@
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeService } from './AppChromeService';
 

--- a/public/app/core/components/AppChrome/AppChromeService.test.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.test.tsx
@@ -69,7 +69,7 @@ describe('AppChromeService', () => {
     it('should not set chromeless for Embed kiosk mode', () => {
       const chromeService = new AppChromeService();
       chromeService.setKioskModeFromUrl('embed');
-      expect(chromeService.state.getValue().chromeless).toBe(false);
+      expect(chromeService.state.getValue().chromeless).toBeFalsy();
     });
 
     it('should not set chromeless for null/undefined kiosk mode', () => {

--- a/public/app/core/components/AppChrome/AppChromeService.test.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.test.tsx
@@ -66,10 +66,10 @@ describe('AppChromeService', () => {
       expect(chromeService.state.getValue().kioskMode).toBeNull();
     });
 
-    it('should set chromeless to true for Embed kiosk mode', () => {
+    it('should not set chromeless for Embed kiosk mode', () => {
       const chromeService = new AppChromeService();
       chromeService.setKioskModeFromUrl('embed');
-      expect(chromeService.state.getValue().chromeless).toBe(true);
+      expect(chromeService.state.getValue().chromeless).toBe(false);
     });
 
     it('should not set chromeless for null/undefined kiosk mode', () => {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -60,6 +60,21 @@ export class AppChromeService {
     returnToPrevious: this.returnToPreviousData,
   });
 
+  public headerHeightObservable = this.state
+    .pipe(
+      map(({ actions, chromeless, kioskMode }) => {
+        if (kioskMode === KioskMode.Full || chromeless) {
+          return 0;
+        } else if (kioskMode === KioskMode.Embed) {
+          return actions ? TOP_BAR_LEVEL_HEIGHT : 0;
+        } else {
+          return actions ? TOP_BAR_LEVEL_HEIGHT : 0; // NI fork: adjusted height to account for removed navigation bar
+        }
+      })
+    )
+    // only emit if the state has actually changed
+    .pipe(distinctUntilChanged());
+
   public setMatchedRoute(route: RouteDescriptor) {
     if (this.currentRoute !== route) {
       this.currentRoute = route;
@@ -87,7 +102,7 @@ export class AppChromeService {
 
     // KioskMode overrides chromeless state
     newState.chromeless =
-      newState.kioskMode === KioskMode.Full || newState.kioskMode === KioskMode.Embed || this.currentRoute?.chromeless;
+      newState.kioskMode === KioskMode.Full || !!this.currentRoute?.chromeless;
 
     if (!this.ignoreStateUpdate(newState, current)) {
       config.featureToggles.unifiedHistory &&

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -65,8 +65,6 @@ export class AppChromeService {
       map(({ actions, chromeless, kioskMode }) => {
         if (kioskMode === KioskMode.Full || chromeless) {
           return 0;
-        } else if (kioskMode === KioskMode.Embed) {
-          return actions ? TOP_BAR_LEVEL_HEIGHT : 0;
         } else {
           return actions ? TOP_BAR_LEVEL_HEIGHT : 0; // NI fork: adjusted height to account for removed navigation bar
         }

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -101,8 +101,7 @@ export class AppChromeService {
     Object.assign(newState, update);
 
     // KioskMode overrides chromeless state
-    newState.chromeless =
-      newState.kioskMode === KioskMode.Full || !!this.currentRoute?.chromeless;
+    newState.chromeless = newState.kioskMode === KioskMode.Full || this.currentRoute?.chromeless;
 
     if (!this.ignoreStateUpdate(newState, current)) {
       config.featureToggles.unifiedHistory &&

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -1,5 +1,5 @@
 import { useObservable } from 'react-use';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
 
 import { AppEvents, NavModel, NavModelItem, PageLayoutType, UrlQueryValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -14,6 +14,7 @@ import { buildBreadcrumbs } from '../Breadcrumbs/utils';
 
 import { logDuplicateUnifiedHistoryEntryEvent } from './History/eventsTracking';
 import { ReturnToPreviousProps } from './ReturnToPrevious/ReturnToPrevious';
+import { getChromeHeaderLevelHeight } from './TopBar/useChromeHeaderHeight';
 import { HistoryEntry } from './types';
 
 export interface AppChromeState {
@@ -66,7 +67,7 @@ export class AppChromeService {
         if (kioskMode === KioskMode.Full || chromeless) {
           return 0;
         } else {
-          return actions ? TOP_BAR_LEVEL_HEIGHT : 0; // NI fork: adjusted height to account for removed navigation bar
+          return actions ? getChromeHeaderLevelHeight() : 0; // NI fork: adjusted height to account for removed navigation bar
         }
       })
     )

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -61,18 +61,20 @@ export class AppChromeService {
     returnToPrevious: this.returnToPreviousData,
   });
 
-  public headerHeightObservable = this.state
-    .pipe(
-      map(({ actions, chromeless, kioskMode }) => {
-        if (kioskMode === KioskMode.Full || chromeless) {
-          return 0;
-        } else {
-          return actions ? getChromeHeaderLevelHeight() : 0; // NI fork: adjusted height to account for removed navigation bar
-        }
-      })
-    )
-    // only emit if the state has actually changed
-    .pipe(distinctUntilChanged());
+  public headerHeightObservable = this.state.pipe(
+    map(({ actions, breadcrumbActions, chromeless, kioskMode }) => {
+      if (kioskMode === KioskMode.Full || chromeless) {
+        return 0;
+      }
+
+      if (kioskMode === KioskMode.Embed) {
+        return actions || breadcrumbActions ? getChromeHeaderLevelHeight() : 0;
+      }
+
+      return actions ? getChromeHeaderLevelHeight() : 0; // NI fork: adjusted height to account for removed navigation bar
+    }),
+    distinctUntilChanged()
+  );
 
   public setMatchedRoute(route: RouteDescriptor) {
     if (this.currentRoute !== route) {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -86,7 +86,8 @@ export class AppChromeService {
     Object.assign(newState, update);
 
     // KioskMode overrides chromeless state
-    newState.chromeless = newState.kioskMode === KioskMode.Full || this.currentRoute?.chromeless;
+    newState.chromeless =
+      newState.kioskMode === KioskMode.Full || newState.kioskMode === KioskMode.Embed || this.currentRoute?.chromeless;
 
     if (!this.ignoreStateUpdate(newState, current)) {
       config.featureToggles.unifiedHistory &&
@@ -227,6 +228,10 @@ export class AppChromeService {
       case '1':
       case true:
         newKioskMode = KioskMode.Full;
+        break;
+      case 'embed':
+        newKioskMode = KioskMode.Embed;
+        break;
     }
 
     if (newKioskMode && newKioskMode !== this.state.getValue().kioskMode) {
@@ -238,6 +243,8 @@ export class AppChromeService {
     switch (mode) {
       case KioskMode.Full:
         return true;
+      case KioskMode.Embed:
+        return 'embed';
       default:
         return null;
     }

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, Stack, useTheme2 } from '@grafana/ui';
-import { useGrafana } from 'app/core/context/GrafanaContext';
+import { t } from 'app/core/internationalization';
 
 import { getChromeHeaderLevelHeight } from '../TopBar/useChromeHeaderHeight';
 
@@ -19,8 +19,6 @@ export const MEGA_MENU_HEADER_TOGGLE_ID = 'mega-menu-header-toggle';
 export function MegaMenuHeader({ handleMegaMenu, handleDockedMenu, onClose }: Props) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const { chrome } = useGrafana();
-  const state = chrome.useState();
 
   return (
     <div className={styles.header}>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -4,7 +4,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, Stack, useTheme2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
-import { t } from 'app/core/internationalization';
 
 import { getChromeHeaderLevelHeight } from '../TopBar/useChromeHeaderHeight';
 
@@ -19,9 +18,9 @@ export const MEGA_MENU_HEADER_TOGGLE_ID = 'mega-menu-header-toggle';
 
 export function MegaMenuHeader({ handleMegaMenu, handleDockedMenu, onClose }: Props) {
   const theme = useTheme2();
+  const styles = getStyles(theme);
   const { chrome } = useGrafana();
   const state = chrome.useState();
-  const styles = getStyles(theme);
 
   return (
     <div className={styles.header}>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, Stack, useTheme2 } from '@grafana/ui';
+import { useGrafana } from 'app/core/context/GrafanaContext';
 import { t } from 'app/core/internationalization';
 
 import { getChromeHeaderLevelHeight } from '../TopBar/useChromeHeaderHeight';
@@ -18,6 +19,8 @@ export const MEGA_MENU_HEADER_TOGGLE_ID = 'mega-menu-header-toggle';
 
 export function MegaMenuHeader({ handleMegaMenu, handleDockedMenu, onClose }: Props) {
   const theme = useTheme2();
+  const { chrome } = useGrafana();
+  const state = chrome.useState();
   const styles = getStyles(theme);
 
   return (

--- a/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
+++ b/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { config, useScopes } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeState } from '../AppChromeService';
 import { useExtensionSidebarContext } from '../ExtensionSidebar/ExtensionSidebarProvider';
@@ -41,9 +42,16 @@ function getHeaderLevelsGivenState(
   scopesEnabled: boolean | undefined = false,
   isLargeScreen: boolean
 ) {
-  // No levels when chromeless or kiosk mode
-  if (chromeState.kioskMode || chromeState.chromeless) {
+  // No levels when chromeless or full kiosk mode
+  if (chromeState.kioskMode === KioskMode.Full || chromeState.chromeless) {
     return 0;
+  }
+
+  // Embed kiosk mode: show one level only when there are actions to display.
+  // SingleTopBarActions is conditionally rendered on actions/breadcrumbActions,
+  // so the header height should be zero when neither is present.
+  if (chromeState.kioskMode === KioskMode.Embed) {
+    return chromeState.actions || chromeState.breadcrumbActions ? 1 : 0;
   }
 
   // Always use two levels scopes is enabled

--- a/public/app/core/navigation/kiosk.ts
+++ b/public/app/core/navigation/kiosk.ts
@@ -8,6 +8,8 @@ export function getKioskMode(queryParams: UrlQueryMap): KioskMode | null {
     case '1':
     case true:
       return KioskMode.Full;
+    case 'embed':
+      return KioskMode.Embed;
     default:
       return null;
   }

--- a/public/app/core/services/keybindingSrv.test.ts
+++ b/public/app/core/services/keybindingSrv.test.ts
@@ -1,0 +1,56 @@
+import { LocationService } from '@grafana/runtime';
+import { KioskMode } from 'app/types';
+
+import { AppChromeService } from '../components/AppChrome/AppChromeService';
+
+import { KeybindingSrv } from './keybindingSrv';
+
+describe('KeybindingSrv', () => {
+  describe('escape key and kiosk mode', () => {
+    let keybindingSrv: KeybindingSrv;
+    let chromeService: AppChromeService;
+    let locationService: LocationService;
+
+    beforeEach(() => {
+      locationService = {
+        getSearchObject: jest.fn().mockReturnValue({}),
+        partial: jest.fn(),
+        push: jest.fn(),
+        getLocation: jest.fn().mockReturnValue({ pathname: '/', search: '' }),
+      } as unknown as LocationService;
+
+      chromeService = new AppChromeService();
+      keybindingSrv = new KeybindingSrv(locationService, chromeService);
+    });
+
+    it('should not exit kiosk mode when in Embed mode', () => {
+      // Set embed kiosk mode
+      chromeService.update({ kioskMode: KioskMode.Embed });
+      const exitSpy = jest.spyOn(chromeService, 'exitKioskMode');
+
+      // Trigger escape (calls private exit method via keybinding)
+      // We need to access the private method - use bracket notation
+      (keybindingSrv as any).exit();
+
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should exit kiosk mode when in Full mode', () => {
+      // Set full kiosk mode
+      chromeService.update({ kioskMode: KioskMode.Full });
+      const exitSpy = jest.spyOn(chromeService, 'exitKioskMode');
+
+      (keybindingSrv as any).exit();
+
+      expect(exitSpy).toHaveBeenCalled();
+    });
+
+    it('should not call exitKioskMode when no kiosk mode is active', () => {
+      const exitSpy = jest.spyOn(chromeService, 'exitKioskMode');
+
+      (keybindingSrv as any).exit();
+
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/core/services/keybindingSrv.test.ts
+++ b/public/app/core/services/keybindingSrv.test.ts
@@ -1,5 +1,5 @@
 import { LocationService } from '@grafana/runtime';
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeService } from '../components/AppChrome/AppChromeService';
 

--- a/public/app/core/services/keybindingSrv.test.ts
+++ b/public/app/core/services/keybindingSrv.test.ts
@@ -3,7 +3,6 @@ import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeService } from '../components/AppChrome/AppChromeService';
 
-// Mock heavy transitive imports that are not needed for these tests
 jest.mock('app/core/utils/explore', () => ({ getExploreUrl: jest.fn() }));
 jest.mock('app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer', () => ({}));
 jest.mock('app/features/dashboard/components/ShareModal/ShareModal', () => ({}));
@@ -36,19 +35,15 @@ describe('KeybindingSrv', () => {
     });
 
     it('should not exit kiosk mode when in Embed mode', () => {
-      // Set embed kiosk mode
       chromeService.update({ kioskMode: KioskMode.Embed });
       const exitSpy = jest.spyOn(chromeService, 'exitKioskMode');
 
-      // Trigger escape (calls private exit method via keybinding)
-      // We need to access the private method - use bracket notation
       (keybindingSrv as any).exit();
 
       expect(exitSpy).not.toHaveBeenCalled();
     });
 
     it('should exit kiosk mode when in Full mode', () => {
-      // Set full kiosk mode
       chromeService.update({ kioskMode: KioskMode.Full });
       const exitSpy = jest.spyOn(chromeService, 'exitKioskMode');
 

--- a/public/app/core/services/keybindingSrv.test.ts
+++ b/public/app/core/services/keybindingSrv.test.ts
@@ -3,6 +3,18 @@ import { KioskMode } from 'app/types/dashboard';
 
 import { AppChromeService } from '../components/AppChrome/AppChromeService';
 
+// Mock heavy transitive imports that are not needed for these tests
+jest.mock('app/core/utils/explore', () => ({ getExploreUrl: jest.fn() }));
+jest.mock('app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer', () => ({}));
+jest.mock('app/features/dashboard/components/ShareModal/ShareModal', () => ({}));
+jest.mock('app/features/dashboard/state/DashboardModel', () => ({}));
+jest.mock('../../features/dashboard/services/TimeSrv', () => ({ getTimeSrv: jest.fn() }));
+jest.mock('app/dev-utils', () => ({ toggleMockApiAndReload: jest.fn(), togglePseudoLocale: jest.fn() }));
+jest.mock('./theme', () => ({ toggleTheme: jest.fn() }));
+jest.mock('./mousetrap', () => ({ mousetrap: { bind: jest.fn(), unbind: jest.fn() } }));
+jest.mock('@grafana/assistant', () => ({ toggleAssistant: jest.fn(), isAssistantAvailable: jest.fn() }));
+jest.mock('../components/help/HelpModal', () => ({}));
+
 import { KeybindingSrv } from './keybindingSrv';
 
 describe('KeybindingSrv', () => {

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -7,7 +7,7 @@ import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal/ShareModal';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { getTimeSrv } from '../../features/dashboard/services/TimeSrv';
 import {

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -7,6 +7,7 @@ import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal/ShareModal';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import { KioskMode } from 'app/types';
 
 import { getTimeSrv } from '../../features/dashboard/services/TimeSrv';
 import {
@@ -172,7 +173,7 @@ export class KeybindingSrv {
     }
 
     const { kioskMode } = this.chromeService.state.getValue();
-    if (kioskMode) {
+    if (kioskMode && kioskMode !== KioskMode.Embed) {
       this.chromeService.exitKioskMode();
     }
   }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { SceneDataLayerControls, SceneVariableSet, TextBoxVariable, VariableValueSelectors } from '@grafana/scenes';
+import { SceneVariableSet, ScopesVariable, TextBoxVariable } from '@grafana/scenes';
 import { KioskMode } from 'app/types/dashboard';
 
 import { DashboardControls, DashboardControlsState } from './DashboardControls';
@@ -141,9 +141,7 @@ describe('DashboardControls', () => {
     });
 
     it('should hide variables and links in embed kiosk mode', async () => {
-      const scene = buildTestScene({
-        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
-      });
+      const scene = buildTestScene();
 
       // Set embed kiosk mode on the parent dashboard
       const dashboard = getDashboardForControls(scene);
@@ -160,9 +158,7 @@ describe('DashboardControls', () => {
     });
 
     it('should show variables and links when NOT in embed kiosk mode', async () => {
-      const scene = buildTestScene({
-        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
-      });
+      const scene = buildTestScene();
 
       // No kiosk mode set (normal mode)
       const renderer = render(<scene.Component model={scene} />);
@@ -176,9 +172,7 @@ describe('DashboardControls', () => {
     });
 
     it('should show variables and links in Full kiosk mode (only chrome is hidden)', async () => {
-      const scene = buildTestScene({
-        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
-      });
+      const scene = buildTestScene();
 
       // Set Full kiosk mode — this hides chrome only, not variables/links
       const dashboard = getDashboardForControls(scene);

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneDataLayerControls, SceneVariableSet, TextBoxVariable, VariableValueSelectors } from '@grafana/scenes';
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { DashboardControls, DashboardControlsState } from './DashboardControls';
 import { DashboardScene } from './DashboardScene';

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { SceneVariableSet, ScopesVariable, TextBoxVariable } from '@grafana/scenes';
+import { SceneDataLayerControls, SceneVariableSet, TextBoxVariable, VariableValueSelectors } from '@grafana/scenes';
+import { KioskMode } from 'app/types';
 
 import { DashboardControls, DashboardControlsState } from './DashboardControls';
 import { DashboardScene } from './DashboardScene';
@@ -138,6 +139,60 @@ describe('DashboardControls', () => {
 
       jest.restoreAllMocks();
     });
+
+    it('should hide variables and links in embed kiosk mode', async () => {
+      const scene = buildTestScene({
+        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
+      });
+
+      // Set embed kiosk mode on the parent dashboard
+      const dashboard = getDashboardForControls(scene);
+      dashboard.setState({ kioskMode: KioskMode.Embed });
+
+      const renderer = render(<scene.Component model={scene} />);
+
+      // Variables submenu should not be visible
+      expect(await renderer.queryByTestId(selectors.pages.Dashboard.SubMenu.submenuItem)).not.toBeInTheDocument();
+      // Links should not be visible
+      expect(await renderer.queryByTestId(selectors.components.DashboardLinks.container)).not.toBeInTheDocument();
+      // Time picker should still be visible
+      expect(await renderer.findByTestId(selectors.components.TimePicker.openButton)).toBeInTheDocument();
+    });
+
+    it('should show variables and links when NOT in embed kiosk mode', async () => {
+      const scene = buildTestScene({
+        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
+      });
+
+      // No kiosk mode set (normal mode)
+      const renderer = render(<scene.Component model={scene} />);
+
+      // Variables submenu should be visible
+      expect(await renderer.findByTestId(selectors.pages.Dashboard.SubMenu.submenuItem)).toBeInTheDocument();
+      // Links should be visible
+      expect(await renderer.findByTestId(selectors.components.DashboardLinks.container)).toBeInTheDocument();
+      // Time picker should be visible
+      expect(await renderer.findByTestId(selectors.components.TimePicker.openButton)).toBeInTheDocument();
+    });
+
+    it('should show variables and links in Full kiosk mode (only chrome is hidden)', async () => {
+      const scene = buildTestScene({
+        variableControls: [new VariableValueSelectors({}), new SceneDataLayerControls()],
+      });
+
+      // Set Full kiosk mode — this hides chrome only, not variables/links
+      const dashboard = getDashboardForControls(scene);
+      dashboard.setState({ kioskMode: KioskMode.Full });
+
+      const renderer = render(<scene.Component model={scene} />);
+
+      // Variables submenu should still be visible in Full mode
+      expect(await renderer.findByTestId(selectors.pages.Dashboard.SubMenu.submenuItem)).toBeInTheDocument();
+      // Links should still be visible in Full mode
+      expect(await renderer.findByTestId(selectors.components.DashboardLinks.container)).toBeInTheDocument();
+      // Time picker should be visible
+      expect(await renderer.findByTestId(selectors.components.TimePicker.openButton)).toBeInTheDocument();
+    });
   });
 
   describe('UrlSync', () => {
@@ -272,4 +327,8 @@ function buildTestScene(state?: Partial<DashboardControlsState>): DashboardContr
   variable.activate();
 
   return dashboard.state.controls as DashboardControls;
+}
+
+function getDashboardForControls(controls: DashboardControls): DashboardScene {
+  return controls.parent as DashboardScene;
 }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -15,7 +15,8 @@ import {
   SceneObjectUrlValues,
   CancelActivationHandler,
 } from '@grafana/scenes';
-import { Box, useStyles2 } from '@grafana/ui';
+import { Box, Stack, useStyles2 } from '@grafana/ui';
+import { KioskMode } from 'app/types';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';
 import { getDashboardSceneFor } from '../utils/utils';
@@ -148,11 +149,14 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
     hideDashboardControls,
   } = model.useState();
   const dashboard = getDashboardSceneFor(model);
-  const { links, editPanel } = dashboard.useState();
+  const { links, editPanel, kioskMode } = dashboard.useState();
   const styles = useStyles2(getStyles);
   const showDebugger = window.location.search.includes('scene-debugger');
 
-  if (!model.hasControls()) {
+  const isKioskEmbed = kioskMode === KioskMode.Embed;
+  const shouldHideVariables = hideVariableControls || isKioskEmbed;
+
+  if (!model.hasControls() && !isKioskEmbed) {
     // To still have spacing when no controls are rendered
 
     return <Box padding={1}>{renderHiddenVariables(dashboard)}</Box>;
@@ -163,25 +167,17 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       data-testid={selectors.pages.Dashboard.Controls}
       className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
     >
-      <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
-        {!hideTimeControls && (
-          <div className={styles.timeControls}>
-            <timePicker.Component model={timePicker} />
-            <refreshPicker.Component model={refreshPicker} />
-          </div>
-        )}
-        {!hideDashboardControls && model.hasDashboardControls() && (
-          <div className={styles.dashboardControlsButton}>
-            <DashboardControlsButton dashboard={dashboard} />
-          </div>
-        )}
-        {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
-      </div>
-      {!hideVariableControls && (
-        <>
-          <VariableControls dashboard={dashboard} />
-          <DashboardDataLayerControls dashboard={dashboard} />
-        </>
+      <Stack grow={1} wrap={'wrap'}>
+        {!shouldHideVariables && variableControls.map((c) => <c.Component model={c} key={c.state.key} />)}
+        <Box grow={1} />
+        {!hideLinksControls && !editPanel && !isKioskEmbed && <DashboardLinksControls links={links} dashboard={dashboard} />}
+        {editPanel && <PanelEditControls panelEditor={editPanel} />}
+      </Stack>
+      {!hideTimeControls && (
+        <Stack justifyContent={'flex-end'}>
+          <timePicker.Component model={timePicker} />
+          <refreshPicker.Component model={refreshPicker} />
+        </Stack>
       )}
       {editPanel && <PanelEditControls panelEditor={editPanel} />}
       {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -154,7 +154,6 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const showDebugger = window.location.search.includes('scene-debugger');
 
   const isKioskEmbed = kioskMode === KioskMode.Embed;
-  const shouldHideVariables = hideVariableControls || isKioskEmbed;
 
   if (!model.hasControls()) {
     // To still have spacing when no controls are rendered
@@ -179,9 +178,9 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
             <DashboardControlsButton dashboard={dashboard} />
           </div>
         )}
-        {!hideLinksControls && !editPanel && !isKioskEmbed && <DashboardLinksControls links={links} dashboard={dashboard} />}
+        {!hideLinksControls && !isKioskEmbed && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
       </div>
-      {!shouldHideVariables && (
+      {!hideVariableControls && !isKioskEmbed && (
         <>
           <VariableControls dashboard={dashboard} />
           <DashboardDataLayerControls dashboard={dashboard} />

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -15,8 +15,8 @@ import {
   SceneObjectUrlValues,
   CancelActivationHandler,
 } from '@grafana/scenes';
-import { Box, Stack, useStyles2 } from '@grafana/ui';
-import { KioskMode } from 'app/types';
+import { Box, useStyles2 } from '@grafana/ui';
+import { KioskMode } from 'app/types/dashboard';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';
 import { getDashboardSceneFor } from '../utils/utils';
@@ -156,7 +156,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const isKioskEmbed = kioskMode === KioskMode.Embed;
   const shouldHideVariables = hideVariableControls || isKioskEmbed;
 
-  if (!model.hasControls() && !isKioskEmbed) {
+  if (!model.hasControls()) {
     // To still have spacing when no controls are rendered
 
     return <Box padding={1}>{renderHiddenVariables(dashboard)}</Box>;
@@ -167,19 +167,26 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       data-testid={selectors.pages.Dashboard.Controls}
       className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
     >
-      <Stack grow={1} wrap={'wrap'}>
-        {!shouldHideVariables && variableControls.map((c) => <c.Component model={c} key={c.state.key} />)}
-        <Box grow={1} />
+      <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
+        {!hideTimeControls && (
+          <div className={styles.timeControls}>
+            <timePicker.Component model={timePicker} />
+            <refreshPicker.Component model={refreshPicker} />
+          </div>
+        )}
+        {!hideDashboardControls && model.hasDashboardControls() && (
+          <div className={styles.dashboardControlsButton}>
+            <DashboardControlsButton dashboard={dashboard} />
+          </div>
+        )}
         {!hideLinksControls && !editPanel && !isKioskEmbed && <DashboardLinksControls links={links} dashboard={dashboard} />}
-        {editPanel && <PanelEditControls panelEditor={editPanel} />}
-      </Stack>
-      {!hideTimeControls && (
-        <Stack justifyContent={'flex-end'}>
-          <timePicker.Component model={timePicker} />
-          <refreshPicker.Component model={refreshPicker} />
-        </Stack>
+      </div>
+      {!shouldHideVariables && (
+        <>
+          <VariableControls dashboard={dashboard} />
+          <DashboardDataLayerControls dashboard={dashboard} />
+        </>
       )}
-      {editPanel && <PanelEditControls panelEditor={editPanel} />}
       {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
     </div>
   );

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -187,6 +187,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
           <DashboardDataLayerControls dashboard={dashboard} />
         </>
       )}
+      {editPanel && <PanelEditControls panelEditor={editPanel} />}
       {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
     </div>
   );

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
@@ -1,11 +1,9 @@
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
-import { SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { KioskMode } from 'app/types/dashboard';
 
-import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
+import { DashboardSceneRenderer } from './DashboardSceneRenderer';
 
 jest.mock('react-router-dom-v5-compat', () => ({
   useParams: () => ({}),
@@ -13,19 +11,23 @@ jest.mock('react-router-dom-v5-compat', () => ({
 }));
 
 jest.mock('app/types/store', () => ({
-  useSelector: (fn: Function) => fn({ navIndex: {} }),
+  useSelector: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('app/core/selectors/navModel', () => ({
-  getNavModel: () => ({ main: { children: [] }, node: { id: 'home', text: 'Home', url: '/' } }),
+  getNavModel: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('app/core/components/Page/Page', () => ({
-  Page: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Page: ({ children }: any) => children,
 }));
 
 jest.mock('../edit-pane/DashboardEditPaneSplitter', () => ({
-  DashboardEditPaneSplitter: () => null,
+  DashboardEditPaneSplitter: ({ body }: any) => body,
+}));
+
+jest.mock('./DashboardScene', () => ({
+  DashboardScene: jest.fn(),
 }));
 
 jest.mock('./PanelSearchLayout', () => ({
@@ -33,22 +35,31 @@ jest.mock('./PanelSearchLayout', () => ({
 }));
 
 jest.mock('./SoloPanelContext', () => ({
+  SoloPanelContextProvider: ({ children }: any) => children,
   useDefineSoloPanelContext: () => null,
-  SoloPanelContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 const STYLE_ID = 'kiosk-embed-panel-menu-hide';
 
-function buildTestScene(kioskMode?: KioskMode): DashboardScene {
-  return new DashboardScene({
-    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-    kioskMode,
-    body: new DefaultGridLayoutManager({
-      grid: new SceneGridLayout({
-        children: [new DashboardGridItem({ body: new VizPanel({ pluginId: 'text' }) })],
-      }),
+function buildMockModel(kioskMode?: KioskMode) {
+  return {
+    useState: () => ({
+      kioskMode,
+      controls: undefined,
+      overlay: undefined,
+      editview: undefined,
+      body: undefined,
+      editPanel: undefined,
+      viewPanel: undefined,
+      panelSearch: {} as any,
+      panelsPerRow: undefined,
+      isEditing: false,
+      layoutOrchestrator: undefined,
     }),
-  });
+    getPageNav: jest.fn().mockReturnValue(undefined),
+    rememberScrollPos: jest.fn(),
+    restoreScrollPos: jest.fn(),
+  };
 }
 
 describe('DashboardSceneRenderer', () => {
@@ -58,39 +69,17 @@ describe('DashboardSceneRenderer', () => {
     });
 
     it('should inject hide-panel-menu style when kioskMode is Embed', () => {
-      const scene = buildTestScene(KioskMode.Embed);
-
-      render(<scene.Component model={scene} />);
-
+      render(<DashboardSceneRenderer model={buildMockModel(KioskMode.Embed) as unknown as DashboardScene} />);
       expect(document.getElementById(STYLE_ID)).toBeInTheDocument();
     });
 
     it('should NOT inject hide-panel-menu style when kioskMode is Full', () => {
-      const scene = buildTestScene(KioskMode.Full);
-
-      render(<scene.Component model={scene} />);
-
+      render(<DashboardSceneRenderer model={buildMockModel(KioskMode.Full) as unknown as DashboardScene} />);
       expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
     });
 
     it('should NOT inject hide-panel-menu style when no kiosk mode is set', () => {
-      const scene = buildTestScene(undefined);
-
-      render(<scene.Component model={scene} />);
-
-      expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
-    });
-
-    it('should remove the style when kioskMode changes away from Embed', () => {
-      const scene = buildTestScene(KioskMode.Embed);
-      render(<scene.Component model={scene} />);
-
-      expect(document.getElementById(STYLE_ID)).toBeInTheDocument();
-
-      act(() => {
-        scene.setState({ kioskMode: undefined });
-      });
-
+      render(<DashboardSceneRenderer model={buildMockModel(undefined) as unknown as DashboardScene} />);
       expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
@@ -1,0 +1,97 @@
+import { act, render } from '@testing-library/react';
+
+import { SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { KioskMode } from 'app/types/dashboard';
+
+import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { DashboardGridItem } from './layout-default/DashboardGridItem';
+import { DashboardScene } from './DashboardScene';
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  useParams: () => ({}),
+  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null }),
+}));
+
+jest.mock('app/types/store', () => ({
+  useSelector: (fn: Function) => fn({ navIndex: {} }),
+}));
+
+jest.mock('app/core/selectors/navModel', () => ({
+  getNavModel: () => ({ main: { children: [] }, node: { id: 'home', text: 'Home', url: '/' } }),
+}));
+
+jest.mock('app/core/components/Page/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../edit-pane/DashboardEditPaneSplitter', () => ({
+  DashboardEditPaneSplitter: () => null,
+}));
+
+jest.mock('./PanelSearchLayout', () => ({
+  PanelSearchLayout: () => null,
+}));
+
+jest.mock('./SoloPanelContext', () => ({
+  useDefineSoloPanelContext: () => null,
+  SoloPanelContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const STYLE_ID = 'kiosk-embed-panel-menu-hide';
+
+function buildTestScene(kioskMode?: KioskMode): DashboardScene {
+  return new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    kioskMode,
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [new DashboardGridItem({ body: new VizPanel({ pluginId: 'text' }) })],
+      }),
+    }),
+  });
+}
+
+describe('DashboardSceneRenderer', () => {
+  describe('embed kiosk mode CSS injection', () => {
+    afterEach(() => {
+      document.getElementById(STYLE_ID)?.remove();
+    });
+
+    it('should inject hide-panel-menu style when kioskMode is Embed', () => {
+      const scene = buildTestScene(KioskMode.Embed);
+
+      render(<scene.Component model={scene} />);
+
+      expect(document.getElementById(STYLE_ID)).toBeInTheDocument();
+    });
+
+    it('should NOT inject hide-panel-menu style when kioskMode is Full', () => {
+      const scene = buildTestScene(KioskMode.Full);
+
+      render(<scene.Component model={scene} />);
+
+      expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
+    });
+
+    it('should NOT inject hide-panel-menu style when no kiosk mode is set', () => {
+      const scene = buildTestScene(undefined);
+
+      render(<scene.Component model={scene} />);
+
+      expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
+    });
+
+    it('should remove the style when kioskMode changes away from Embed', () => {
+      const scene = buildTestScene(KioskMode.Embed);
+      render(<scene.Component model={scene} />);
+
+      expect(document.getElementById(STYLE_ID)).toBeInTheDocument();
+
+      act(() => {
+        scene.setState({ kioskMode: undefined });
+      });
+
+      expect(document.getElementById(STYLE_ID)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -6,8 +6,8 @@ import { ScopesContext } from '@grafana/runtime';
 import { SceneComponentProps } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
-import { useSelector } from 'app/types/store';
 import { KioskMode } from 'app/types/dashboard';
+import { useSelector } from 'app/types/store';
 
 import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -6,7 +6,8 @@ import { ScopesContext } from '@grafana/runtime';
 import { SceneComponentProps } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
-import { KioskMode, useSelector } from 'app/types';
+import { useSelector } from 'app/types/store';
+import { KioskMode } from 'app/types/dashboard';
 
 import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
 
@@ -15,8 +16,19 @@ import { PanelSearchLayout } from './PanelSearchLayout';
 import { SoloPanelContextProvider, useDefineSoloPanelContext } from './SoloPanelContext';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
-  const { controls, overlay, editview, editPanel, viewPanelScene, panelSearch, panelsPerRow, isEditing, kioskMode } =
-    model.useState();
+  const {
+    controls,
+    overlay,
+    editview,
+    body,
+    editPanel,
+    viewPanel,
+    panelSearch,
+    panelsPerRow,
+    isEditing,
+    layoutOrchestrator,
+    kioskMode,
+  } = model.useState();
   const { type } = useParams();
   const location = useLocation();
   const scopesContext = useContext(ScopesContext);

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -6,7 +6,7 @@ import { ScopesContext } from '@grafana/runtime';
 import { SceneComponentProps } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
-import { useSelector } from 'app/types/store';
+import { KioskMode, useSelector } from 'app/types';
 
 import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
 
@@ -15,18 +15,8 @@ import { PanelSearchLayout } from './PanelSearchLayout';
 import { SoloPanelContextProvider, useDefineSoloPanelContext } from './SoloPanelContext';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
-  const {
-    controls,
-    overlay,
-    editview,
-    body,
-    editPanel,
-    viewPanel,
-    panelSearch,
-    panelsPerRow,
-    isEditing,
-    layoutOrchestrator,
-  } = model.useState();
+  const { controls, overlay, editview, editPanel, viewPanelScene, panelSearch, panelsPerRow, isEditing, kioskMode } =
+    model.useState();
   const { type } = useParams();
   const location = useLocation();
   const scopesContext = useContext(ScopesContext);
@@ -43,6 +33,20 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
       : getNavModel(navIndex, 'dashboards/browse');
   const isSettingsOpen = editview !== undefined;
   const soloPanelContext = useDefineSoloPanelContext(viewPanel);
+
+  // Hide panel menu buttons in embed kiosk mode
+  useEffect(() => {
+    if (kioskMode === KioskMode.Embed) {
+      const style = document.createElement('style');
+      style.id = 'kiosk-embed-panel-menu-hide';
+      style.textContent = '[data-testid^="data-testid Panel menu"], [data-testid="panel-menu-button"] { display: none !important; }';
+      document.head.appendChild(style);
+      return () => {
+        style.remove();
+      };
+    }
+    return undefined;
+  }, [kioskMode]);
 
   // Remember scroll pos when going into view panel, edit panel or settings
   useMemo(() => {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -34,12 +34,48 @@ describe('DashboardSceneUrlSync', () => {
       expect(scene.state.kioskMode).toBe(KioskMode.Full);
     });
 
+    it('Should set embed kiosk mode when url has kiosk=embed', () => {
+      const scene = buildTestScene();
+
+      scene.urlSync?.updateFromUrl({ kiosk: 'embed' });
+      expect(scene.state.kioskMode).toBe(KioskMode.Embed);
+    });
+
+    it('Should NOT set kiosk mode for random/invalid values', () => {
+      const scene = buildTestScene();
+
+      scene.urlSync?.updateFromUrl({ kiosk: 'random' });
+      expect(scene.state.kioskMode).toBe(undefined);
+
+      scene.urlSync?.updateFromUrl({ kiosk: 'tv' });
+      expect(scene.state.kioskMode).toBe(undefined);
+
+      scene.urlSync?.updateFromUrl({ kiosk: 'false' });
+      expect(scene.state.kioskMode).toBe(undefined);
+    });
+
     it('Should get the kiosk mode from the scene state', () => {
       const scene = buildTestScene();
 
       expect(scene.urlSync?.getUrlState().kiosk).toBe(undefined);
       scene.setState({ kioskMode: KioskMode.Full });
       expect(scene.urlSync?.getUrlState().kiosk).toBe('true');
+    });
+
+    it('Should get embed kiosk url state from the scene state', () => {
+      const scene = buildTestScene();
+
+      expect(scene.urlSync?.getUrlState().kiosk).toBe(undefined);
+      scene.setState({ kioskMode: KioskMode.Embed });
+      expect(scene.urlSync?.getUrlState().kiosk).toBe('embed');
+    });
+
+    it('Should return undefined kiosk url state when no kiosk mode is set', () => {
+      const scene = buildTestScene();
+
+      expect(scene.urlSync?.getUrlState().kiosk).toBe(undefined);
+      scene.setState({ kioskMode: undefined });
+      expect(scene.urlSync?.getUrlState().kiosk).toBe(undefined);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -26,7 +26,9 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       viewPanel: state.viewPanel,
       editview: state.editview?.getUrlKey(),
       editPanel: state.editPanel?.getUrlKey() || undefined,
-      kiosk: state.kioskMode === KioskMode.Full ? '' : state.kioskMode === KioskMode.Embed ? 'embed' : undefined,
+      kiosk: state.kioskMode === KioskMode.Full
+        ? 'true'
+        : state.kioskMode === KioskMode.Embed ? 'embed' : undefined,
       shareView: state.shareView,
       orgId: contextSrv.user.orgId.toString(),
     };

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -26,7 +26,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       viewPanel: state.viewPanel,
       editview: state.editview?.getUrlKey(),
       editPanel: state.editPanel?.getUrlKey() || undefined,
-      kiosk: state.kioskMode === KioskMode.Full ? 'true' : undefined,
+      kiosk: state.kioskMode === KioskMode.Full ? '' : state.kioskMode === KioskMode.Embed ? 'embed' : undefined,
       shareView: state.shareView,
       orgId: contextSrv.user.orgId.toString(),
     };
@@ -120,6 +120,8 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
     if (typeof values.kiosk === 'string') {
       if (values.kiosk === 'true' || values.kiosk === '') {
         update.kioskMode = KioskMode.Full;
+      } else if (values.kiosk === 'embed') {
+        update.kioskMode = KioskMode.Embed;
       }
     }
 

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.test.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.test.tsx
@@ -8,13 +8,13 @@ import { LocationServiceProvider, locationService } from '@grafana/runtime';
 import { SceneQueryRunner, SceneTimeRange, UrlSyncContextProvider, VizPanel } from '@grafana/scenes';
 import { mockLocalStorage } from 'app/features/alerting/unified/mocks';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
-import { DashboardMeta } from 'app/types/dashboard';
+import { DashboardMeta, KioskMode } from 'app/types/dashboard';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { DashboardInteractions } from '../utils/interactions';
 
 import { DashboardScene } from './DashboardScene';
-import { ToolbarActions } from './NavToolbarActions';
+import { NavToolbarActions, ToolbarActions } from './NavToolbarActions';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 
 jest.mock('../utils/interactions', () => ({
@@ -200,6 +200,34 @@ describe('NavToolbarActions', () => {
       setup();
       const newExportButton = screen.getByRole('button', { name: /export dashboard/i });
       expect(newExportButton).toBeInTheDocument();
+    });
+  });
+
+  describe('NavToolbarActions in embed kiosk mode', () => {
+    it('should clear toolbar actions when kioskMode is Embed', () => {
+      const dashboard = new DashboardScene({
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        uid: 'dash-1',
+        title: 'hello',
+        kioskMode: KioskMode.Embed,
+        body: DefaultGridLayoutManager.fromVizPanels([]),
+      });
+      const context = getGrafanaContextMock();
+      locationService.push('/');
+
+      render(
+        <TestProvider grafanaContext={context}>
+          <LocationServiceProvider service={locationService}>
+            <UrlSyncContextProvider scene={dashboard}>
+              <NavToolbarActions dashboard={dashboard} />
+            </UrlSyncContextProvider>
+          </LocationServiceProvider>
+        </TestProvider>
+      );
+
+      expect(context.chrome.state.getValue().actions).toBeNull();
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+      expect(screen.queryByText('Share')).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -23,8 +23,11 @@ import { contextSrv } from 'app/core/core';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { trackDashboardSceneEditButtonClicked } from 'app/features/dashboard-scene/utils/tracking';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
-import { ScopesSelector } from 'app/features/scopes';
-import { KioskMode } from 'app/types';
+import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
+import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
+import { useSelector } from 'app/types/store';
+import { KioskMode } from 'app/types/dashboard';
 
 import { selectFolderRepository } from '../../provisioning/utils/selectors';
 import { PanelEditor, buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -46,7 +49,7 @@ interface Props {
 }
 
 export const NavToolbarActions = memo<Props>(({ dashboard }) => {
-  const id = useId();
+   const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
   const { kioskMode } = dashboard.useState();
 
   if (kioskMode === KioskMode.Embed) {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -26,8 +26,8 @@ import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
-import { useSelector } from 'app/types/store';
 import { KioskMode } from 'app/types/dashboard';
+import { useSelector } from 'app/types/store';
 
 import { selectFolderRepository } from '../../provisioning/utils/selectors';
 import { PanelEditor, buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -49,7 +49,7 @@ interface Props {
 }
 
 export const NavToolbarActions = memo<Props>(({ dashboard }) => {
-   const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
+  const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
   const { kioskMode } = dashboard.useState();
 
   if (kioskMode === KioskMode.Embed) {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -23,10 +23,8 @@ import { contextSrv } from 'app/core/core';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { trackDashboardSceneEditButtonClicked } from 'app/features/dashboard-scene/utils/tracking';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
-import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
-import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
-import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
-import { useSelector } from 'app/types/store';
+import { ScopesSelector } from 'app/features/scopes';
+import { KioskMode } from 'app/types';
 
 import { selectFolderRepository } from '../../provisioning/utils/selectors';
 import { PanelEditor, buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -48,7 +46,12 @@ interface Props {
 }
 
 export const NavToolbarActions = memo<Props>(({ dashboard }) => {
-  const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
+  const id = useId();
+  const { kioskMode } = dashboard.useState();
+
+  if (kioskMode === KioskMode.Embed) {
+    return <AppChromeUpdate actions={null} />;
+  }
 
   return hasNewToolbar ? (
     <AppChromeUpdate

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -31,7 +31,6 @@ import { DashboardScene } from './DashboardScene';
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelMenuBehavior } from './PanelMenuBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-import { KioskMode } from 'app/types/dashboard';
 
 const mocks = {
   contextSrv: jest.mocked(contextSrv),
@@ -703,42 +702,6 @@ describe('panelMenuBehavior', () => {
       });
     });
 
-    it('should have menu items when NOT in embed kiosk mode', async () => {
-      const { scene, menu, panel } = await buildTestScene({});
-
-      // Explicitly no kiosk mode
-      scene.setState({ kioskMode: undefined });
-
-      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
-
-      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
-
-      menu.activate();
-
-      await new Promise((r) => setTimeout(r, 1));
-
-      expect(menu.state.items?.length).toBeGreaterThan(0);
-      expect(menu.state.items?.[0].text).toBe('View');
-    });
-
-    it('should have menu items in Full kiosk mode (only chrome hidden, not menus)', async () => {
-      const { scene, menu, panel } = await buildTestScene({});
-
-      scene.setState({ kioskMode: KioskMode.Full });
-
-      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
-
-      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
-
-      menu.activate();
-
-      await new Promise((r) => setTimeout(r, 1));
-
-      expect(menu.state.items?.length).toBeGreaterThan(0);
-      expect(menu.state.items?.[0].text).toBe('View');
-    });
   });
 
   describe('onCreateAlert', () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -554,21 +554,153 @@ describe('panelMenuBehavior', () => {
       expect(menu.state.items?.[0].text).toBe('Explore');
     });
 
-    it('should have empty menu items in embed kiosk mode', async () => {
-      const { scene, menu, panel } = await buildTestScene({});
+    describe('plugin links', () => {
+      it('should not show Metrics Drilldown menu when no Metrics Drilldown links exist', async () => {
+        getPluginExtensionsMock.mockReturnValue({
+          extensions: [
+            {
+              id: '1',
+              pluginId: '...',
+              type: PluginExtensionTypes.link,
+              title: 'Other Extension',
+              description: 'Some other extension',
+              path: '/a/other-app/action',
+            },
+          ],
+        });
 
-      scene.setState({ kioskMode: KioskMode.Embed });
+        const { menu, panel } = await buildTestScene({});
 
-      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
-      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
 
-      menu.activate();
+        menu.activate();
 
-      await new Promise((r) => setTimeout(r, 1));
+        await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(0);
+        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
+        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
+
+        expect(metricsDrilldownMenu).toBeUndefined();
+        expect(extensionsMenu).toBeDefined();
+        expect(extensionsMenu?.subMenu).toEqual([
+          expect.objectContaining({
+            text: 'Other Extension',
+            href: '/a/other-app/action',
+          }),
+        ]);
+      });
+
+      it('should separate Metrics Drilldown links into their own menu', async () => {
+        getPluginExtensionsMock.mockReturnValue({
+          extensions: [
+            {
+              id: '1',
+              pluginId: '...',
+              type: PluginExtensionTypes.link,
+              title: 'Open in Metrics Drilldown',
+              description: 'Open current query in Metrics Drilldown',
+              path: '/a/grafana-metricsdrilldown-app/trail',
+              category: 'metrics-drilldown',
+            },
+            {
+              id: '2',
+              pluginId: '...',
+              type: PluginExtensionTypes.link,
+              title: 'Other Extension',
+              description: 'Some other extension',
+              path: '/a/other-app/action',
+            },
+          ],
+        });
+
+        const { menu, panel } = await buildTestScene({});
+
+        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+
+        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+
+        menu.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(menu.state.items?.length).toBe(8); // 6 base items + 2 extension menus
+
+        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
+        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
+
+        expect(metricsDrilldownMenu).toBeDefined();
+        expect(metricsDrilldownMenu?.iconClassName).toBe('code-branch');
+        expect(metricsDrilldownMenu?.subMenu).toEqual([
+          expect.objectContaining({
+            text: 'metrics-drilldown',
+            type: 'group',
+            subMenu: expect.arrayContaining([
+              expect.objectContaining({
+                text: 'Open in Metrics Drilld...',
+                href: '/a/grafana-metricsdrilldown-app/trail',
+              }),
+            ]),
+          }),
+        ]);
+
+        expect(extensionsMenu).toBeDefined();
+        expect(extensionsMenu?.iconClassName).toBe('plug');
+        expect(extensionsMenu?.subMenu).toEqual([
+          expect.objectContaining({
+            text: 'Other Extension',
+            href: '/a/other-app/action',
+          }),
+        ]);
+      });
+
+      it('should not show extensions menu when no non-Metrics Drilldown links exist', async () => {
+        getPluginExtensionsMock.mockReturnValue({
+          extensions: [
+            {
+              id: '1',
+              pluginId: '...',
+              type: PluginExtensionTypes.link,
+              title: 'Open in Metrics Drilldown',
+              description: 'Open current query in Metrics Drilldown',
+              path: '/a/grafana-metricsdrilldown-app/trail',
+              category: 'metrics-drilldown',
+            },
+          ],
+        });
+
+        const { menu, panel } = await buildTestScene({});
+
+        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+
+        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+
+        menu.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
+        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
+
+        expect(metricsDrilldownMenu).toBeDefined();
+        expect(extensionsMenu).toBeUndefined();
+        expect(metricsDrilldownMenu?.subMenu).toEqual([
+          expect.objectContaining({
+            text: 'metrics-drilldown',
+            type: 'group',
+            subMenu: expect.arrayContaining([
+              expect.objectContaining({
+                text: 'Open in Metrics Drilld...',
+                href: '/a/grafana-metricsdrilldown-app/trail',
+              }),
+            ]),
+          }),
+        ]);
+      });
     });
 
     it('should have menu items when NOT in embed kiosk mode', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -23,7 +23,7 @@ import { GetExploreUrlArguments } from 'app/core/utils/explore';
 import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
 import { scenesPanelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import * as storeModule from 'app/store/store';
-import { AccessControlAction } from 'app/types/accessControl';
+import { AccessControlAction, KioskMode } from 'app/types';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 
@@ -553,153 +553,58 @@ describe('panelMenuBehavior', () => {
       expect(menu.state.items?.[0].text).toBe('Explore');
     });
 
-    describe('plugin links', () => {
-      it('should not show Metrics Drilldown menu when no Metrics Drilldown links exist', async () => {
-        getPluginExtensionsMock.mockReturnValue({
-          extensions: [
-            {
-              id: '1',
-              pluginId: '...',
-              type: PluginExtensionTypes.link,
-              title: 'Other Extension',
-              description: 'Some other extension',
-              path: '/a/other-app/action',
-            },
-          ],
-        });
+    it('should have empty menu items in embed kiosk mode', async () => {
+      const { scene, menu, panel } = await buildTestScene({});
 
-        const { menu, panel } = await buildTestScene({});
+      scene.setState({ kioskMode: KioskMode.Embed });
 
-        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
-        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
 
-        menu.activate();
+      menu.activate();
 
-        await new Promise((r) => setTimeout(r, 1));
+      await new Promise((r) => setTimeout(r, 1));
 
-        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
-        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
+      expect(menu.state.items?.length).toBe(0);
+    });
 
-        expect(metricsDrilldownMenu).toBeUndefined();
-        expect(extensionsMenu).toBeDefined();
-        expect(extensionsMenu?.subMenu).toEqual([
-          expect.objectContaining({
-            text: 'Other Extension',
-            href: '/a/other-app/action',
-          }),
-        ]);
-      });
+    it('should have menu items when NOT in embed kiosk mode', async () => {
+      const { scene, menu, panel } = await buildTestScene({});
 
-      it('should separate Metrics Drilldown links into their own menu', async () => {
-        getPluginExtensionsMock.mockReturnValue({
-          extensions: [
-            {
-              id: '1',
-              pluginId: '...',
-              type: PluginExtensionTypes.link,
-              title: 'Open in Metrics Drilldown',
-              description: 'Open current query in Metrics Drilldown',
-              path: '/a/grafana-metricsdrilldown-app/trail',
-              category: 'metrics-drilldown',
-            },
-            {
-              id: '2',
-              pluginId: '...',
-              type: PluginExtensionTypes.link,
-              title: 'Other Extension',
-              description: 'Some other extension',
-              path: '/a/other-app/action',
-            },
-          ],
-        });
+      // Explicitly no kiosk mode
+      scene.setState({ kioskMode: undefined });
 
-        const { menu, panel } = await buildTestScene({});
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
-        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
 
-        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+      menu.activate();
 
-        menu.activate();
+      await new Promise((r) => setTimeout(r, 1));
 
-        await new Promise((r) => setTimeout(r, 1));
+      expect(menu.state.items?.length).toBeGreaterThan(0);
+      expect(menu.state.items?.[0].text).toBe('View');
+    });
 
-        expect(menu.state.items?.length).toBe(8); // 6 base items + 2 extension menus
+    it('should have menu items in Full kiosk mode (only chrome hidden, not menus)', async () => {
+      const { scene, menu, panel } = await buildTestScene({});
 
-        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
-        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
+      scene.setState({ kioskMode: KioskMode.Full });
 
-        expect(metricsDrilldownMenu).toBeDefined();
-        expect(metricsDrilldownMenu?.iconClassName).toBe('code-branch');
-        expect(metricsDrilldownMenu?.subMenu).toEqual([
-          expect.objectContaining({
-            text: 'metrics-drilldown',
-            type: 'group',
-            subMenu: expect.arrayContaining([
-              expect.objectContaining({
-                text: 'Open in Metrics Drilld...',
-                href: '/a/grafana-metricsdrilldown-app/trail',
-              }),
-            ]),
-          }),
-        ]);
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
-        expect(extensionsMenu).toBeDefined();
-        expect(extensionsMenu?.iconClassName).toBe('plug');
-        expect(extensionsMenu?.subMenu).toEqual([
-          expect.objectContaining({
-            text: 'Other Extension',
-            href: '/a/other-app/action',
-          }),
-        ]);
-      });
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
 
-      it('should not show extensions menu when no non-Metrics Drilldown links exist', async () => {
-        getPluginExtensionsMock.mockReturnValue({
-          extensions: [
-            {
-              id: '1',
-              pluginId: '...',
-              type: PluginExtensionTypes.link,
-              title: 'Open in Metrics Drilldown',
-              description: 'Open current query in Metrics Drilldown',
-              path: '/a/grafana-metricsdrilldown-app/trail',
-              category: 'metrics-drilldown',
-            },
-          ],
-        });
+      menu.activate();
 
-        const { menu, panel } = await buildTestScene({});
+      await new Promise((r) => setTimeout(r, 1));
 
-        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
-
-        mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
-        mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
-
-        menu.activate();
-
-        await new Promise((r) => setTimeout(r, 1));
-
-        const metricsDrilldownMenu = menu.state.items?.find((i) => i.text === 'Metrics drilldown');
-        const extensionsMenu = menu.state.items?.find((i) => i.text === 'Extensions');
-
-        expect(metricsDrilldownMenu).toBeDefined();
-        expect(extensionsMenu).toBeUndefined();
-        expect(metricsDrilldownMenu?.subMenu).toEqual([
-          expect.objectContaining({
-            text: 'metrics-drilldown',
-            type: 'group',
-            subMenu: expect.arrayContaining([
-              expect.objectContaining({
-                text: 'Open in Metrics Drilld...',
-                href: '/a/grafana-metricsdrilldown-app/trail',
-              }),
-            ]),
-          }),
-        ]);
-      });
+      expect(menu.state.items?.length).toBeGreaterThan(0);
+      expect(menu.state.items?.[0].text).toBe('View');
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -23,7 +23,7 @@ import { GetExploreUrlArguments } from 'app/core/utils/explore';
 import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
 import { scenesPanelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import * as storeModule from 'app/store/store';
-import { AccessControlAction, KioskMode } from 'app/types';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 
@@ -31,6 +31,7 @@ import { DashboardScene } from './DashboardScene';
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelMenuBehavior } from './PanelMenuBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { KioskMode } from 'app/types/dashboard';
 
 const mocks = {
   contextSrv: jest.mocked(contextSrv),

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -701,7 +701,6 @@ describe('panelMenuBehavior', () => {
         ]);
       });
     });
-
   });
 
   describe('onCreateAlert', () => {

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
-import { KioskMode } from 'app/types';
+import { KioskMode } from 'app/types/dashboard';
 
 import { DashboardModel } from '../../state/DashboardModel';
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -3,7 +3,6 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { locationService } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { KioskMode } from 'app/types';
 

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { locationService } from '@grafana/runtime';
+import { GrafanaContext } from 'app/core/context/GrafanaContext';
+import { KioskMode } from 'app/types';
+
+import { DashboardModel } from '../../state/DashboardModel';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
+
+import { DashNav } from './DashNav';
+
+// DashNav renders via AppChromeUpdate which injects actions into the chrome.
+// We mock AppChromeUpdate to directly render the actions prop so we can test what DashNav produces.
+jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
+  AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div data-testid="dashnav-actions">{actions}</div>,
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    ...jest.requireActual('@grafana/runtime').locationService,
+    getLocation: () => ({ pathname: '/d/test', search: '', hash: '' }),
+    partial: jest.fn(),
+    getHistory: jest.requireActual('@grafana/runtime').locationService.getHistory,
+  },
+}));
+
+function setup(dashboard: DashboardModel, kioskMode?: KioskMode | null) {
+  const store = {
+    getState: () => ({
+      navIndex: {},
+    }),
+    dispatch: jest.fn(),
+    subscribe: jest.fn(),
+    replaceReducer: jest.fn(),
+    [Symbol.observable]: jest.fn(),
+  };
+  const context = getGrafanaContextMock();
+
+  return render(
+    <GrafanaContext.Provider value={context}>
+      <Provider store={store as any}>
+        <MemoryRouter>
+          <DashNav
+            dashboard={dashboard}
+            title={dashboard.title}
+            isFullscreen={false}
+            kioskMode={kioskMode}
+            hideTimePicker={false}
+            folderTitle=""
+          />
+        </MemoryRouter>
+      </Provider>
+    </GrafanaContext.Provider>
+  );
+}
+
+describe('DashNav', () => {
+  let dashboard: DashboardModel;
+
+  beforeEach(() => {
+    dashboard = createDashboardModelFixture({
+      title: 'Test Dashboard',
+      uid: 'test-uid',
+    });
+    dashboard.meta = {
+      ...dashboard.meta,
+      canStar: true,
+      canSave: true,
+      canEdit: true,
+      canShare: true,
+      showSettings: true,
+    };
+  });
+
+  describe('in embed kiosk mode', () => {
+    it('should only render time controls and hide other actions', () => {
+      setup(dashboard, KioskMode.Embed);
+      // Star, save, settings, share buttons should NOT be rendered
+      expect(screen.queryByRole('button', { name: /mark as favorite/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /save dashboard/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /dashboard settings/i })).not.toBeInTheDocument();
+    });
+
+    it('should not render left actions', () => {
+      setup(dashboard, KioskMode.Embed);
+      expect(screen.queryByRole('button', { name: /mark as favorite/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
-import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { GrafanaContext } from 'app/core/context/GrafanaContext';
+import { setStarred } from 'app/core/reducers/navBarTree';
+import { removeNavIndex, updateNavIndex } from 'app/core/reducers/navModel';
 import { KioskMode } from 'app/types/dashboard';
+import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 
 import { DashboardModel } from '../../state/DashboardModel';
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
@@ -15,6 +15,15 @@ import { DashNav } from './DashNav';
 // We mock AppChromeUpdate to directly render the actions prop so we can test what DashNav produces.
 jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
   AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div data-testid="dashnav-actions">{actions}</div>,
+}));
+
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  }),
 }));
 
 jest.mock('@grafana/runtime', () => ({
@@ -28,32 +37,22 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 function setup(dashboard: DashboardModel, kioskMode?: KioskMode | null) {
-  const store = {
-    getState: () => ({
-      navIndex: {},
-    }),
-    dispatch: jest.fn(),
-    subscribe: jest.fn(),
-    replaceReducer: jest.fn(),
-    [Symbol.observable]: jest.fn(),
-  };
-  const context = getGrafanaContextMock();
-
   return render(
-    <GrafanaContext.Provider value={context}>
-      <Provider store={store as any}>
-        <MemoryRouter>
-          <DashNav
-            dashboard={dashboard}
-            title={dashboard.title}
-            isFullscreen={false}
-            kioskMode={kioskMode}
-            hideTimePicker={false}
-            folderTitle=""
-          />
-        </MemoryRouter>
-      </Provider>
-    </GrafanaContext.Provider>
+    <MemoryRouter>
+      <DashNav
+        navIndex={{}}
+        dashboard={dashboard}
+        title={dashboard.title}
+        isFullscreen={false}
+        kioskMode={kioskMode}
+        hideTimePicker={false}
+        folderTitle=""
+        removeNavIndex={removeNavIndex}
+        setStarred={setStarred}
+        updateTimeZoneForSession={updateTimeZoneForSession}
+        updateNavIndex={updateNavIndex}
+      />
+    </MemoryRouter>
   );
 }
 
@@ -82,11 +81,6 @@ describe('DashNav', () => {
       expect(screen.queryByRole('button', { name: /mark as favorite/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /save dashboard/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /dashboard settings/i })).not.toBeInTheDocument();
-    });
-
-    it('should not render left actions', () => {
-      setup(dashboard, KioskMode.Embed);
-      expect(screen.queryByRole('button', { name: /mark as favorite/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -11,8 +11,6 @@ import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardF
 
 import { DashNav } from './DashNav';
 
-// DashNav renders via AppChromeUpdate which injects actions into the chrome.
-// We mock AppChromeUpdate to directly render the actions prop so we can test what DashNav produces.
 jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
   AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div data-testid="dashnav-actions">{actions}</div>,
 }));

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -266,11 +266,15 @@ export const DashNav = memo<Props>((props) => {
   };
 
   const renderRightActions = () => {
-    const { dashboard, isFullscreen, hideTimePicker } = props;
+    const { dashboard, isFullscreen, hideTimePicker, kioskMode } = props;
     const { canSave, canEdit, showSettings, canShare } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
     const buttons: ReactNode[] = [];
+
+    if (kioskMode === KioskMode.Embed) {
+      return [renderTimeControls()];
+    }
 
     if (isPlaylistRunning()) {
       return [renderPlaylistControls(), renderTimeControls()];

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -297,4 +297,14 @@ describe('DashboardPage', () => {
       });
     });
   });
+
+  describe('When in embed kiosk mode', () => {
+    it('should render page toolbar but not submenu', async () => {
+      setup({ dashboard: getTestDashboard(), queryParams: { kiosk: 'embed' } });
+      await waitFor(() => {
+        expect(screen.queryAllByTestId(selectors.pages.Dashboard.DashNav.navV2)).toHaveLength(1);
+        expect(screen.queryAllByLabelText(selectors.pages.Dashboard.SubMenu.submenu)).toHaveLength(0);
+      });
+    });
+  });
 });

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -367,7 +367,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     const inspectPanel = this.getInspectPanel();
     const showSubMenu = !editPanel && !kioskMode && !this.props.queryParams.editview && dashboard.isSubMenuVisible();
 
-    const showToolbar = kioskMode !== KioskMode.Full && !queryParams.editview && !initError;
+    const showToolbar = kioskMode !== KioskMode.Full && kioskMode !== KioskMode.Embed && !queryParams.editview && !initError;
 
     const pageClassName = cx({
       [styles.fullScreenPanel]: Boolean(viewPanel),

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -114,6 +114,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
       display: 'none',
     },
   }),
+  embedKiosk: css({
+    '[data-testid^="data-testid Panel menu"], [data-testid="panel-menu-button"]': {
+      display: 'none !important',
+    },
+  }),
 });
 
 export class UnthemedDashboardPage extends PureComponent<Props, State> {
@@ -367,10 +372,11 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     const inspectPanel = this.getInspectPanel();
     const showSubMenu = !editPanel && !kioskMode && !this.props.queryParams.editview && dashboard.isSubMenuVisible();
 
-    const showToolbar = kioskMode !== KioskMode.Full && kioskMode !== KioskMode.Embed && !queryParams.editview && !initError;
+    const showToolbar = kioskMode !== KioskMode.Full && !queryParams.editview && !initError;
 
     const pageClassName = cx({
       [styles.fullScreenPanel]: Boolean(viewPanel),
+      [styles.embedKiosk]: kioskMode === KioskMode.Embed,
       'page-hidden': Boolean(queryParams.editview || editPanel),
     });
 

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -132,6 +132,7 @@ export interface DashboardInitError {
 
 export enum KioskMode {
   Full = 'full',
+  Embed = 'embed',
 }
 
 export type GetMutableDashboardModelFn = () => DashboardModel | null;


### PR DESCRIPTION
**What is this feature?**

[User Story 3222079](https://dev.azure.com/ni/DevCentral/_workitems/edit/3222079): Prevent ESC key and hide menu options in the dashboard

Adds a custom `?kiosk=embed` kiosk mode designed for embedding Grafana dashboards in iframes within SystemLink. This mode hides UI chrome while keeping the time picker accessible.

Refer [comment](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullRequest/1205539?discussionId=9438884#1773864755) for more details

**Why do we need this feature?**

When `?kiosk=embed` is appended to a dashboard URL:

- **Hides**: Navigation sidebar, top toolbar (settings/share/favorite), template variables, dashboard links, and panel context menus (3-dot button)
- **Keeps visible**: Time picker and refresh picker
- **Escape key locked**: Users cannot exit embed mode by pressing Escape (unlike Full kiosk mode)

## Changes

### Core (both architectures)

| File | Change |
|------|--------|
| `public/app/types/dashboard.ts` | Added `Embed = 'embed'` to `KioskMode` enum |
| `public/app/core/navigation/kiosk.ts` | `getKioskMode` handles `'embed'` → `KioskMode.Embed` |
| `public/app/core/components/AppChrome/AppChromeService.tsx` | URL parsing for `kiosk=embed`; embed mode is NOT chromeless; `headerHeightObservable` returns 0 when no actions |
| `public/app/core/components/AppChrome/AppChrome.tsx` | Hide `SingleTopBar`, `MegaMenu`, `AppChromeMenu`, `CommandPalette` in embed mode; keep `SingleTopBarActions` (time picker) |
| `public/app/core/services/keybindingSrv.ts` | Prevent Escape key from exiting embed mode |

### Scenes path (dashboardScene FF enabled)

| File | Change |
|------|--------|
| `public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts` | URL state serialization/deserialization for `kiosk=embed` |
| `public/app/features/dashboard-scene/scene/DashboardControls.tsx` | Hide variables and links in embed mode |
| `public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx` | CSS injection to hide panel menu buttons |
| `public/app/features/dashboard-scene/scene/NavToolbarActions.tsx` | Return `null` actions in embed mode (hides Star, Edit, Export, Share) |

### Old DashboardPage path (dashboardScene FF disabled)

| File | Change |
|------|--------|
| `public/app/features/dashboard/containers/DashboardPage.tsx` | Toolbar shown but `embedKiosk` CSS class hides panel menu buttons |
| `public/app/features/dashboard/components/DashNav/DashNav.tsx` | `renderRightActions()` returns only time controls in embed mode; left actions hidden |

**dashboardScene feature flag disabled **

<img width="1919" height="408" alt="image" src="https://github.com/user-attachments/assets/35160a44-52d9-4693-97c5-a7723df8e378" />

**dashboardScene feature flag disabled with kiosk mode embed**

<img width="1915" height="379" alt="image" src="https://github.com/user-attachments/assets/1bcd6970-f270-48e0-ae21-51b0d8e390c5" />

**dashboardScene feature flag enabled**
<img width="1911" height="531" alt="image" src="https://github.com/user-attachments/assets/589c2f7e-2238-4ab6-93af-c9bbdff26848" />

**dashboardScene feature flag enabled with kiosk mode embed**
<img width="1913" height="492" alt="image" src="https://github.com/user-attachments/assets/ff02246a-5429-4feb-90d8-9c7ab047cea4" />



**Who is this feature for?**

[Add information on what kind of user the feature is for.]

This feature is for embedding dashboards in iframes within a web application. It provides a clean, distraction-free view for end users who interact with dashboards in an embedded context.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

NA

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
