### PR TITLE
fix: propagate context.Canceled as HTTP 499 instead of HTTP 500

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -66,7 +66,7 @@ func (hs *HTTPServer) GetAnnotations(c *contextmodel.ReqContext) response.Respon
 
 	items, err := hs.annotationsRepo.Find(c.Req.Context(), query)
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to get annotations", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to get annotations", err)
 	}
 
 	for _, item := range items {

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -427,6 +427,59 @@ func TestAPI_Annotations(t *testing.T) {
 	}
 }
 
+func TestAPI_GetAnnotations_ContextCanceled(t *testing.T) {
+	repo := &annotations.FakeAnnotationsRepo{}
+	repo.On("Find", mock.Anything, mock.Anything).Return(nil, context.Canceled)
+
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.annotationsRepo = repo
+		hs.Features = featuremgmt.WithFeatures()
+		hs.DashboardService = &dashboards.FakeDashboardService{}
+		hs.folderService = &foldertest.FakeService{}
+		hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+		hs.AccessControl.RegisterScopeAttributeResolver(AnnotationTypeScopeResolver(hs.annotationsRepo, hs.Features, hs.DashboardService.(*dashboards.FakeDashboardService), hs.folderService.(*foldertest.FakeService)))
+	})
+
+	req := webtest.RequestWithSignedInUser(
+		server.NewRequest(http.MethodGet, "/api/annotations", nil),
+		authedUserWithPermissions(1, 1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionAnnotationsRead, Scope: accesscontrol.ScopeAnnotationsAll},
+		}),
+	)
+	res, err := server.SendJSON(req)
+	require.NoError(t, err)
+	assert.Equal(t, 499, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+}
+
+func TestAPI_GetAnnotations_GenericError(t *testing.T) {
+	repo := &annotations.FakeAnnotationsRepo{}
+	// Use a non-context.Canceled error to verify ErrOrFallback falls back to 500
+	repo.On("Find", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.annotationsRepo = repo
+		hs.Features = featuremgmt.WithFeatures()
+		hs.DashboardService = &dashboards.FakeDashboardService{}
+		hs.folderService = &foldertest.FakeService{}
+		hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+		hs.AccessControl.RegisterScopeAttributeResolver(AnnotationTypeScopeResolver(hs.annotationsRepo, hs.Features, hs.DashboardService.(*dashboards.FakeDashboardService), hs.folderService.(*foldertest.FakeService)))
+	})
+
+	req := webtest.RequestWithSignedInUser(
+		server.NewRequest(http.MethodGet, "/api/annotations", nil),
+		authedUserWithPermissions(1, 1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionAnnotationsRead, Scope: accesscontrol.ScopeAnnotationsAll},
+		}),
+	)
+	res, err := server.SendJSON(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+}
+
 func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 	rootDashUID := "root-dashboard"
 	folderDashUID := "folder-dashboard"

--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -56,6 +56,9 @@ func (api *AccessControlAPI) getUserActions(c *contextmodel.ReqContext) response
 	reloadCache := c.QueryBool("reloadcache")
 	permissions, err := api.Service.GetUserPermissions(ctx, c.SignedInUser, ac.Options{ReloadCache: reloadCache})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return response.ErrOrFallback(http.StatusInternalServerError, "could not get user actions", err)
+		}
 		return response.JSON(http.StatusInternalServerError, err)
 	}
 

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -65,6 +66,41 @@ func TestAPI_getUserActions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPI_getUserActions_ContextCanceled(t *testing.T) {
+	acSvc := actest.FakeService{ExpectedErr: context.Canceled}
+	api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{})
+	api.RegisterAPIEndpoints()
+
+	server := webtest.NewServer(t, api.RouteRegister)
+	req := server.NewGetRequest("/api/access-control/user/actions")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID:       1,
+		Permissions: map[int64]map[string][]string{},
+	})
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+	require.Equal(t, 499, res.StatusCode)
+}
+
+func TestAPI_getUserActions_GenericError(t *testing.T) {
+	// Use a non-context.Canceled error to verify the original JSON 500 path is preserved
+	acSvc := actest.FakeService{ExpectedErr: context.DeadlineExceeded}
+	api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{})
+	api.RegisterAPIEndpoints()
+
+	server := webtest.NewServer(t, api.RouteRegister)
+	req := server.NewGetRequest("/api/access-control/user/actions")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID:       1,
+		Permissions: map[int64]map[string][]string{},
+	})
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 }
 
 func TestAPI_getUserPermissions(t *testing.T) {

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -77,7 +78,11 @@ func (authz *AuthService) Authorize(ctx context.Context, query annotations.ItemQ
 		}
 
 		visibleDashboards, err = authz.dashboardsWithVisibleAnnotations(ctx, query)
+
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, err
+			}
 			return nil, ErrAccessControlInternal.Errorf("failed to fetch dashboards: %w", err)
 		}
 	}

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -2,8 +2,10 @@ package accesscontrol
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -106,4 +108,71 @@ func TestDashboardsWithVisibleAnnotations(t *testing.T) {
 	assert.Equal(t, map[string]int64{"uid1": 101}, result)
 	// Ensure SearchDashboards was called with correct query (including DashboardUID filter)
 	dashSvc.AssertCalled(t, "SearchDashboards", mock.Anything, queryWithDashboardUID)
+}
+
+func TestAuthorize_ContextCanceled(t *testing.T) {
+	store := db.InitTestDB(t)
+
+	usr := &user.SignedInUser{
+		OrgID: 1,
+		Permissions: map[int64]map[string][]string{
+			1: {
+				"annotations:read": {"annotations:type:dashboard"},
+			},
+		},
+	}
+
+	dashSvc := &dashboards.FakeDashboardService{}
+	dashSvc.On("SearchDashboards", mock.Anything, mock.Anything).Return(nil, context.Canceled)
+
+	authz := &AuthService{
+		db:                        store,
+		features:                  featuremgmt.WithFeatures(),
+		dashSvc:                   dashSvc,
+		searchDashboardsPageLimit: 100,
+	}
+
+	_, err := authz.Authorize(context.Background(), annotations.ItemQuery{
+		SignedInUser: usr,
+		OrgID:        1,
+	})
+
+	assert.ErrorIs(t, err, context.Canceled, "expected context.Canceled to be propagated unwrapped")
+
+	var grafanaErr errutil.Error
+	assert.False(t, errors.As(err, &grafanaErr), "expected context.Canceled NOT to be wrapped as errutil.Error")
+}
+
+func TestAuthorize_GenericErrorIsWrapped(t *testing.T) {
+	store := db.InitTestDB(t)
+
+	usr := &user.SignedInUser{
+		OrgID: 1,
+		Permissions: map[int64]map[string][]string{
+			1: {
+				"annotations:read": {"annotations:type:dashboard"},
+			},
+		},
+	}
+
+	genericErr := errors.New("db connection failed")
+	dashSvc := &dashboards.FakeDashboardService{}
+	dashSvc.On("SearchDashboards", mock.Anything, mock.Anything).Return(nil, genericErr)
+
+	authz := &AuthService{
+		db:                        store,
+		features:                  featuremgmt.WithFeatures(),
+		dashSvc:                   dashSvc,
+		searchDashboardsPageLimit: 100,
+	}
+
+	_, err := authz.Authorize(context.Background(), annotations.ItemQuery{
+		SignedInUser: usr,
+		OrgID:        1,
+	})
+
+	// It must be a Grafana typed error (ErrAccessControlInternal)
+	var grafanaErr errutil.Error
+	assert.True(t, errors.As(err, &grafanaErr), "expected generic error to be wrapped as errutil.Error")
+	assert.Equal(t, "annotations.accesscontrol.internal", grafanaErr.MessageID)
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -352,6 +352,11 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, id *authn.Identity, 
 		if errors.Is(err, user.ErrUserNotFound) {
 			return errFetchingSignedInUserNotFound.Errorf("%w", err)
 		}
+
+		if errors.Is(err, context.Canceled) {
+        	return err
+		}
+
 		return errFetchingSignedInUser.Errorf("failed to resolve user: %w", err)
 	}
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -354,7 +354,7 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, id *authn.Identity, 
 		}
 
 		if errors.Is(err, context.Canceled) {
-        	return err
+			return err
 		}
 
 		return errFetchingSignedInUser.Errorf("failed to resolve user: %w", err)

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -13,6 +13,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -961,6 +962,53 @@ func TestUserSync_FetchSyncedUserHook(t *testing.T) {
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
+}
+
+func TestUserSync_FetchSyncedUserHook_ContextCanceled(t *testing.T) {
+	userSvc := &usertest.FakeUserService{ExpectedError: context.Canceled}
+	s := UserSync{
+		userService: userSvc,
+		tracer:      tracing.InitializeTracerForTest(),
+	}
+
+	identity := &authn.Identity{
+		ID:   "1",
+		Type: claims.TypeUser,
+		ClientParams: authn.ClientParams{
+			FetchSyncedUser: true,
+		},
+	}
+
+	err := s.FetchSyncedUserHook(context.Background(), identity, &authn.Request{})
+
+	require.ErrorIs(t, err, context.Canceled, "expected context.Canceled to be propagated unwrapped")
+
+	var grafanaErr errutil.Error
+	assert.False(t, errors.As(err, &grafanaErr), "expected context.Canceled NOT to be wrapped as errutil.Error")
+}
+
+func TestUserSync_FetchSyncedUserHook_GenericErrorIsWrapped(t *testing.T) {
+	genericErr := errors.New("some db error")
+	userSvc := &usertest.FakeUserService{ExpectedError: genericErr}
+	s := UserSync{
+		userService: userSvc,
+		tracer:      tracing.InitializeTracerForTest(),
+	}
+
+	identity := &authn.Identity{
+		ID:   "1",
+		Type: claims.TypeUser,
+		ClientParams: authn.ClientParams{
+			FetchSyncedUser: true,
+		},
+	}
+
+	err := s.FetchSyncedUserHook(context.Background(), identity, &authn.Request{})
+
+	// It must be wrapped as errFetchingSignedInUser (errutil.Internal with id user.sync.fetch)
+	var grafanaErr errutil.Error
+	assert.True(t, errors.As(err, &grafanaErr), "expected generic error to be wrapped as errutil.Error")
+	assert.Equal(t, "user.sync.fetch", grafanaErr.MessageID)
 }
 
 func TestUserSync_CatalogLoginHook(t *testing.T) {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1543,6 +1543,9 @@ func (dr *DashboardServiceImpl) fetchFolderNames(ctx context.Context, query *das
 
 	folders, err := dr.folderService.SearchFolders(serviceCtx, search)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		return nil, folder.ErrInternal.Errorf("failed to fetch parent folders: %w", err)
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	dashboardv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -2684,4 +2686,45 @@ func TestGetDashboardsByLibraryPanelUID(t *testing.T) {
 	}
 
 	k8sCliMock.AssertExpectations(t)
+}
+
+func TestFetchFolderNames_ContextCanceled(t *testing.T) {
+	fakeFolders := foldertest.NewFakeService()
+	fakeFolders.ExpectedError = context.Canceled
+
+	service := &DashboardServiceImpl{
+		cfg:           setting.NewCfg(),
+		features:      featuremgmt.WithFeatures(),
+		folderService: fakeFolders,
+		metrics:       newDashboardsMetrics(prometheus.NewRegistry()),
+	}
+
+	query := &dashboards.FindPersistedDashboardsQuery{OrgId: 1}
+	_, err := service.fetchFolderNames(context.Background(), query, nil)
+
+	require.ErrorIs(t, err, context.Canceled, "expected context.Canceled to be propagated unwrapped")
+
+	var grafanaErr errutil.Error
+	assert.False(t, errors.As(err, &grafanaErr), "expected context.Canceled NOT to be wrapped as errutil.Error")
+}
+
+func TestFetchFolderNames_GenericErrorIsWrapped(t *testing.T) {
+	genericErr := errors.New("some db error")
+	fakeFolders := foldertest.NewFakeService()
+	fakeFolders.ExpectedError = genericErr
+
+	service := &DashboardServiceImpl{
+		cfg:           setting.NewCfg(),
+		features:      featuremgmt.WithFeatures(),
+		folderService: fakeFolders,
+		metrics:       newDashboardsMetrics(prometheus.NewRegistry()),
+	}
+
+	query := &dashboards.FindPersistedDashboardsQuery{OrgId: 1}
+	_, err := service.fetchFolderNames(context.Background(), query, nil)
+
+	// It must be wrapped as folder.ErrInternal
+	var grafanaErr errutil.Error
+	assert.True(t, errors.As(err, &grafanaErr), "expected generic error to be wrapped as errutil.Error")
+	assert.Equal(t, "folder.internal", grafanaErr.MessageID)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- A bug fix. When a user navigates away from a page mid-request, Go's HTTP server cancels the request context with context.Canceled. Several endpoints were wrapping this error inside structured errutil.Error types (which carry StatusInternal), so response.ErrOrFallback never got the chance to route it correctly. This PR intercepts context.Canceled before wrapping in each affected path, allowing ErrOrFallback to map it to HTTP 499 ("Client Closed Request"), which is the correct status and also completely silent in Grafana's error logger.

**Why do we need this feature?**

- These HTTP 500 errors are false positives triggered by normal browser navigation. They pollute Grafana's error logs and monitoring dashboards, making it harder to spot real server errors.

**Who is this feature for?**

- SRE teams monitoring Grafana logs, reduces noise from false-positive 500 errors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

- Each affected error path adds an errors.Is(err, context.Canceled) guard before wrapping in a structured error type. No existing error-handling logic is removed.
Files changed: annotations.go, accesscontrol.go, user_sync.go, dashboard_service.go, api.go

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
