### PR TITLE
Dashboard loading: Hide "Cancel loading dashboard" button in embed kiosk mode

### DIFF
--- a/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.test.tsx
+++ b/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { locationService } from '@grafana/runtime';
+
+import { DashboardInitPhase } from 'app/types/dashboard';
+
+import { DashboardLoading } from './DashboardLoading';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    ...jest.requireActual('@grafana/runtime').locationService,
+    getSearchObject: jest.fn(),
+    push: jest.fn(),
+  },
+}));
+
+const mockGetSearchObject = locationService.getSearchObject as jest.Mock;
+const mockPush = locationService.push as jest.Mock;
+
+describe('DashboardLoading', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without kiosk=embed', () => {
+    beforeEach(() => {
+      mockGetSearchObject.mockReturnValue({});
+    });
+
+    it('renders the init phase text', () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      expect(screen.getByText(DashboardInitPhase.Fetching)).toBeInTheDocument();
+    });
+
+    it('renders the Cancel loading dashboard button', () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      expect(screen.getByRole('button', { name: /cancel loading dashboard/i })).toBeInTheDocument();
+    });
+
+    it('navigates to home when Cancel loading dashboard is clicked', async () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      await userEvent.click(screen.getByRole('button', { name: /cancel loading dashboard/i }));
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('with kiosk=embed', () => {
+    beforeEach(() => {
+      mockGetSearchObject.mockReturnValue({ kiosk: 'embed' });
+    });
+
+    it('renders the init phase text', () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      expect(screen.getByText(DashboardInitPhase.Fetching)).toBeInTheDocument();
+    });
+
+    it('hides the Cancel loading dashboard button', () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      expect(screen.queryByRole('button', { name: /cancel loading dashboard/i })).not.toBeInTheDocument();
+    });
+
+    it('does not navigate when dashboard is loading', async () => {
+      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.test.tsx
+++ b/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.test.tsx
@@ -40,8 +40,9 @@ describe('DashboardLoading', () => {
     });
 
     it('navigates to home when Cancel loading dashboard is clicked', async () => {
+      const user = userEvent.setup();
       render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
-      await userEvent.click(screen.getByRole('button', { name: /cancel loading dashboard/i }));
+      await user.click(screen.getByRole('button', { name: /cancel loading dashboard/i }));
       expect(mockPush).toHaveBeenCalledWith('/');
     });
   });
@@ -59,11 +60,6 @@ describe('DashboardLoading', () => {
     it('hides the Cancel loading dashboard button', () => {
       render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
       expect(screen.queryByRole('button', { name: /cancel loading dashboard/i })).not.toBeInTheDocument();
-    });
-
-    it('does not navigate when dashboard is loading', async () => {
-      render(<DashboardLoading initPhase={DashboardInitPhase.Fetching} />);
-      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 });

--- a/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.tsx
+++ b/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.tsx
@@ -4,7 +4,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { Button, Spinner, Stack, useStyles2 } from '@grafana/ui';
-import { DashboardInitPhase } from 'app/types/dashboard';
+import { getKioskMode } from 'app/core/navigation/kiosk';
+import { DashboardInitPhase, KioskMode } from 'app/types/dashboard';
 
 export interface Props {
   initPhase: DashboardInitPhase;
@@ -12,6 +13,9 @@ export interface Props {
 
 export const DashboardLoading = ({ initPhase }: Props) => {
   const styles = useStyles2(getStyles);
+  const kioskMode = getKioskMode(locationService.getSearchObject());
+  const isEmbedKiosk = kioskMode === KioskMode.Embed;
+
   const cancelVariables = () => {
     locationService.push('/');
   };
@@ -23,11 +27,13 @@ export const DashboardLoading = ({ initPhase }: Props) => {
           <Stack alignItems="center" justifyContent="center" gap={0.5}>
             <Spinner inline={true} /> {initPhase}
           </Stack>{' '}
-          <Stack alignItems="center" justifyContent="center">
-            <Button variant="secondary" size="md" icon="repeat" onClick={cancelVariables}>
-              <Trans i18nKey="dashboard.dashboard-loading.cancel-loading-dashboard">Cancel loading dashboard</Trans>
-            </Button>
-          </Stack>
+          {!isEmbedKiosk && (
+            <Stack alignItems="center" justifyContent="center">
+              <Button variant="secondary" size="md" icon="repeat" onClick={cancelVariables}>
+                <Trans i18nKey="dashboard.dashboard-loading.cancel-loading-dashboard">Cancel loading dashboard</Trans>
+              </Button>
+            </Stack>
+          )}
         </Stack>
       </div>
     </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Task 3953485](https://ni.visualstudio.com/DevCentral/_workitems/edit/3953485): Clicking "Cancel Loading Dashboard" Loads the Grafana Home Page Within the Overview Tab

Hide the **Cancel loading dashboard** button when a dashboard is opened in `kiosk=embed` mode. The loading state still shows, but embedded dashboards no longer expose a button that would navigate the iframe away from the current page.

**Why do we need this feature?**

In embedded dashboard mode, the cancel action can break the embed experience by navigating users to the Grafana home page inside the SystemLink app. Hiding this button keeps users in the intended embedded dashboard context and preserves a focused dashboard view. This also aligns with kiosk embed behaviour, which is designed to remove navigation controls that distract from dashboard content.

**Scenarios**

Scenario 1: `dashboardScene` disabled, kiosk not embed

[DashboardPage ](https://github.com/ni/grafana/blob/dde73808ca59f4ea9cb034c8a67e1da7e1bcdeca/public/app/features/dashboard/containers/DashboardPage.tsx#L369) renders [DashboardLoading](https://github.com/ni/grafana/blob/main/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.tsx), and the cancel button still shows. This is the existing behavior.
<img width="1642" height="615" alt="image" src="https://github.com/user-attachments/assets/448af1eb-12f9-49be-b62f-b8431b0c8439" />

### Scenario 2: `dashboardScene` disabled, `kiosk=embed`

`DashboardPage` renders [DashboardLoading](https://github.com/ni/grafana/blob/main/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.tsx), `getKioskMode()` returns `KioskMode.Embed`, and the cancel button is hidden. This is the behavior this fix addresses.
<img width="1646" height="657" alt="image" src="https://github.com/user-attachments/assets/092b0505-b2f1-46a2-8185-f5f96ebc689b" />

### Scenario 3: `dashboardScene` enabled

[DashboardScenePage ](https://github.com/ni/grafana/blob/main/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx) handles loading instead. It uses [PageLoader](https://github.com/ni/grafana/blob/main/public/app/core/components/PageLoader/PageLoader.tsx), which is just a simple loading indicator with no button and no navigation. [DashboardLoading](https://github.com/ni/grafana/blob/main/public/app/features/dashboard/components/DashboardLoading/DashboardLoading.tsx) is not used in this path, so there is no cancel button to hide.

**Who is this feature for?**

This feature is for embedding dashboards in iframes within a web application. It provides a clean, distraction-free view for end users who interact with dashboards in an embedded context.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
