### PR TITLE
Data links: preserve kiosk mode during internal navigation

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1114,51 +1114,6 @@ describe('getLinksSupplier', () => {
     );
   });
 
-  it('appends kiosk param to internal (Explore) links when user is in kiosk mode', () => {
-    locationUtil.initialize({
-      config: { appSubUrl: '' } as GrafanaConfig,
-      getVariablesUrlParams: () => ({}),
-      getTimeRangeForUrl: () => ({ from: 'now-7d', to: 'now' }),
-    });
-    window.history.replaceState({}, '', '/d/source?kiosk=embed');
-
-    const datasourceUid = '1234';
-    const f0 = createDataFrame({
-      name: 'A',
-      fields: [
-        {
-          name: 'message',
-          type: FieldType.string,
-          values: [10, 20],
-          config: {
-            links: [
-              {
-                url: '',
-                title: '',
-                internal: {
-                  datasourceUid: datasourceUid,
-                  datasourceName: 'testDS',
-                  query: '12345',
-                },
-              },
-            ],
-          },
-          display: (v) => ({ numeric: Number(v), text: String(v) }),
-        },
-      ],
-    });
-
-    const supplier = getLinksSupplier(f0, f0.fields[0], {}, (value) => value);
-    const links = supplier({ valueRowIndex: 0 });
-
-    const encodeURIParams = `{"datasource":"${datasourceUid}","queries":["12345"]}`;
-    const baseHref = `/explore?left=${encodeURIComponent(encodeURIParams)}`;
-    expect(links.length).toBe(1);
-    expect(links[0].href).toBe(`${baseHref}&kiosk=embed`);
-
-    window.history.replaceState({}, '', '/');
-  });
-
   describe('dynamic links', () => {
     beforeEach(() => {
       locationUtil.initialize({
@@ -1428,6 +1383,98 @@ describe('getLinksSupplier', () => {
 
       const supplier = getLinksSupplier(dataframe, dataframe.fields[0], {}, replaceIdentity);
       const links = supplier({});
+
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toBe(expectedHref);
+    });
+  });
+
+  const exploreModeKioskLinkCases = [
+    {
+      title: 'when user is in embed kiosk mode, kiosk is preserved in Explore link',
+      currentUrl: '/d/source?kiosk=embed',
+      expectedKiosk: 'embed',
+    },
+    {
+      title: 'when user is in full kiosk mode, kiosk is preserved in Explore link',
+      currentUrl: '/d/source?kiosk=true',
+      expectedKiosk: 'true',
+    },
+    {
+      title: 'when user is in legacy full kiosk mode (kiosk=1), kiosk is preserved in Explore link',
+      currentUrl: '/d/source?kiosk=1',
+      expectedKiosk: '1',
+    },
+    {
+      title: 'when user is not in kiosk mode, Explore link is not modified',
+      currentUrl: '/d/source?orgId=1',
+      expectedKiosk: null,
+    },
+    {
+      title: 'when kiosk param has an unrecognized value, Explore link is not modified',
+      currentUrl: '/d/source?kiosk=unknown',
+      expectedKiosk: null,
+    },
+    {
+      title: 'when kiosk param contains a script injection attempt, Explore link is not modified',
+      currentUrl: '/d/source?kiosk=<script>alert(1)</script>',
+      expectedKiosk: null,
+    },
+  ];
+
+  describe('kiosk mode preservation for internal (Explore) links', () => {
+    const datasourceUid = '1234';
+    const encodeURIParams = `{"datasource":"${datasourceUid}","queries":["12345"]}`;
+    const baseHref = `/explore?left=${encodeURIComponent(encodeURIParams)}`;
+    let dataframe: ReturnType<typeof createDataFrame>;
+
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: () => ({}),
+        getTimeRangeForUrl: () => ({ from: 'now-7d', to: 'now' }),
+      });
+      dataframe = createDataFrame({
+        name: 'A',
+        fields: [
+          {
+            name: 'message',
+            type: FieldType.string,
+            values: [10, 20],
+            config: {
+              links: [
+                {
+                  url: '',
+                  title: '',
+                  internal: {
+                    datasourceUid,
+                    datasourceName: 'testDS',
+                    query: '12345',
+                  },
+                },
+              ],
+            },
+            display: (v) => ({ numeric: Number(v), text: String(v) }),
+          },
+        ],
+      });
+    });
+
+    afterEach(() => {
+      window.history.replaceState({}, '', '/');
+      locationUtil.initialize({
+        config: { appSubUrl: '/subUrl' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    it.each(exploreModeKioskLinkCases)('$title', ({ currentUrl, expectedKiosk }) => {
+      window.history.replaceState({}, '', currentUrl);
+      const supplier = getLinksSupplier(dataframe, dataframe.fields[0], {}, (value) => value);
+      const expectedHref = expectedKiosk ? `${baseHref}&kiosk=${expectedKiosk}` : baseHref;
+
+      const links = supplier({ valueRowIndex: 0 });
 
       expect(links).toHaveLength(1);
       expect(links[0].href).toBe(expectedHref);

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1280,10 +1280,10 @@ describe('getLinksSupplier', () => {
       expectedHref: 'tel:+1234567890',
     },
     {
-      title: 'when user clicks a javascript pseudo-link, kiosk logic does not modify it',
+      title: 'when user clicks a javascript pseudo-link, sanitized href is not modified by kiosk logic',
       currentUrl: '/d/source?kiosk=embed',
       linkUrl: 'javascript:void(0)',
-      expectedHref: 'javascript:void(0)',
+      expectedHref: 'about:blank',
     },
     {
       title: 'when user is not in kiosk mode, clicked link is not modified',
@@ -1306,8 +1306,8 @@ describe('getLinksSupplier', () => {
     {
       title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
       currentUrl: '/d/source?kiosk=embed',
-      linkUrl: 'https://grafana.acme.com/d/target?orgId=1',
-      expectedHref: 'https://grafana.acme.com/d/target?orgId=1&kiosk=embed',
+      linkUrl: 'http://localhost/d/target?orgId=1',
+      expectedHref: 'http://localhost/d/target?orgId=1&kiosk=embed',
     },
     {
       title: 'when user is in kiosk mode and clicks a relative dashboard link, kiosk is preserved',
@@ -1324,32 +1324,50 @@ describe('getLinksSupplier', () => {
   ];
 
   const replaceIdentity: InterpolateFunction = (value) => value;
-  it.each(kioskLinkCases)('$title', ({ currentUrl, linkUrl, expectedHref }) => {
-    window.history.replaceState({}, '', currentUrl);
-
-    const f0 = createDataFrame({
-      name: 'A',
-      fields: [
-        {
-          name: 'message',
-          type: FieldType.string,
-          config: {
-            links: [
-              {
-                url: linkUrl,
-                title: 'target',
-              },
-            ],
-          },
-        },
-      ],
+  describe('kiosk mode preservation', () => {
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
     });
 
-    const supplier = getLinksSupplier(f0, f0.fields[0], {}, replaceIdentity);
-    const links = supplier({});
+    afterEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/subUrl' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
 
-    expect(links).toHaveLength(1);
-    expect(links[0].href).toBe(expectedHref);
+    it.each(kioskLinkCases)('$title', ({ currentUrl, linkUrl, expectedHref }) => {
+      window.history.replaceState({}, '', currentUrl);
+
+      const dataframe = createDataFrame({
+        name: 'A',
+        fields: [
+          {
+            name: 'message',
+            type: FieldType.string,
+            config: {
+              links: [
+                {
+                  url: linkUrl,
+                  title: 'target',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const supplier = getLinksSupplier(dataframe, dataframe.fields[0], {}, replaceIdentity);
+      const links = supplier({});
+
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toBe(expectedHref);
+    });
   });
 });
 

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1286,10 +1286,10 @@ describe('getLinksSupplier', () => {
       expectedHref: 'about:blank',
     },
     {
-      title: 'when user is not in kiosk mode, clicked link is not modified',
-      currentUrl: '/d/source?orgId=1',
-      linkUrl: '/d/target?orgId=1',
-      expectedHref: '/d/target?orgId=1',
+      title: 'when user clicks an external absolute link, kiosk is not appended',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: 'https://example.com/target?orgId=1',
+      expectedHref: 'https://example.com/target?orgId=1',
     },
     {
       title: 'when destination link already defines kiosk mode, user click keeps destination kiosk value',
@@ -1298,12 +1298,11 @@ describe('getLinksSupplier', () => {
       expectedHref: '/d/target?kiosk=embed',
     },
     {
-      title: 'when user clicks an external absolute link, kiosk is not appended',
-      currentUrl: '/d/source?kiosk=true',
-      linkUrl: 'https://example.com/target?orgId=1',
-      expectedHref: 'https://example.com/target?orgId=1',
+      title: 'when user is not in kiosk mode, clicked link is not modified',
+      currentUrl: '/d/source?orgId=1',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1',
     },
-    // Successful kiosk preservation cases
     {
       title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
       currentUrl: '/d/source?kiosk=embed',

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1304,6 +1304,18 @@ describe('getLinksSupplier', () => {
       expectedHref: '/d/target?orgId=1',
     },
     {
+      title: 'when kiosk param has an unrecognized value, clicked link is not modified',
+      currentUrl: '/d/source?kiosk=unknown',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1',
+    },
+    {
+      title: 'when kiosk param contains a script injection attempt, clicked link is not modified',
+      currentUrl: '/d/source?kiosk=<script>alert(1)</script>',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1',
+    },
+    {
       title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
       currentUrl: '/d/source?kiosk=embed',
       linkUrl: 'http://localhost/d/target?orgId=1',

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1316,7 +1316,8 @@ describe('getLinksSupplier', () => {
       expectedHref: '/d/target?orgId=1&kiosk=embed',
     },
     {
-      title: 'when user is in kiosk mode and clicks a relative dashboard link with hash, kiosk is added and hash is preserved',
+      title:
+        'when user is in kiosk mode and clicks a relative dashboard link with hash, kiosk is added and hash is preserved',
       currentUrl: '/d/source?kiosk=embed',
       linkUrl: '/d/target?orgId=1#panel-5',
       expectedHref: '/d/target?orgId=1&kiosk=embed#panel-5',

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1292,17 +1292,18 @@ describe('getLinksSupplier', () => {
       expectedHref: '/d/target?orgId=1',
     },
     {
-      title: 'when user clicks an external absolute link, kiosk is not appended',
-      currentUrl: '/d/source?kiosk=true',
-      linkUrl: 'https://example.com/target?orgId=1',
-      expectedHref: 'https://example.com/target?orgId=1',
-    },
-    {
       title: 'when destination link already defines kiosk mode, user click keeps destination kiosk value',
       currentUrl: '/d/source?kiosk=true',
       linkUrl: '/d/target?kiosk=embed',
       expectedHref: '/d/target?kiosk=embed',
     },
+    {
+      title: 'when user clicks an external absolute link, kiosk is not appended',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: 'https://example.com/target?orgId=1',
+      expectedHref: 'https://example.com/target?orgId=1',
+    },
+    // Successful kiosk preservation cases
     {
       title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
       currentUrl: '/d/source?kiosk=embed',

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1322,6 +1322,13 @@ describe('getLinksSupplier', () => {
       linkUrl: '/d/target?orgId=1#panel-5',
       expectedHref: '/d/target?orgId=1&kiosk=embed#panel-5',
     },
+    {
+      title:
+        'when destination query contains special characters, link values are encoded and kiosk is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '/d/target?query=hello%20world&path=a%2Fb#panel-5',
+      expectedHref: '/d/target?query=hello%20world&path=a%2Fb&kiosk=embed#panel-5',
+    },
   ];
 
   const replaceIdentity: InterpolateFunction = (value) => value;

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1114,6 +1114,51 @@ describe('getLinksSupplier', () => {
     );
   });
 
+  it('appends kiosk param to internal (Explore) links when user is in kiosk mode', () => {
+    locationUtil.initialize({
+      config: { appSubUrl: '' } as GrafanaConfig,
+      getVariablesUrlParams: () => ({}),
+      getTimeRangeForUrl: () => ({ from: 'now-7d', to: 'now' }),
+    });
+    window.history.replaceState({}, '', '/d/source?kiosk=embed');
+
+    const datasourceUid = '1234';
+    const f0 = createDataFrame({
+      name: 'A',
+      fields: [
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: [10, 20],
+          config: {
+            links: [
+              {
+                url: '',
+                title: '',
+                internal: {
+                  datasourceUid: datasourceUid,
+                  datasourceName: 'testDS',
+                  query: '12345',
+                },
+              },
+            ],
+          },
+          display: (v) => ({ numeric: Number(v), text: String(v) }),
+        },
+      ],
+    });
+
+    const supplier = getLinksSupplier(f0, f0.fields[0], {}, (value) => value);
+    const links = supplier({ valueRowIndex: 0 });
+
+    const encodeURIParams = `{"datasource":"${datasourceUid}","queries":["12345"]}`;
+    const baseHref = `/explore?left=${encodeURIComponent(encodeURIParams)}`;
+    expect(links.length).toBe(1);
+    expect(links[0].href).toBe(`${baseHref}&kiosk=embed`);
+
+    window.history.replaceState({}, '', '/');
+  });
+
   describe('dynamic links', () => {
     beforeEach(() => {
       locationUtil.initialize({

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1253,6 +1253,104 @@ describe('getLinksSupplier', () => {
     // check that onClick variable replacer has scoped vars bound to it
     expect(replaceSpy.mock.calls[1][1]).toHaveProperty('foo', { text: 'bar', value: 'bar' });
   });
+
+  const kioskLinkCases = [
+    {
+      title: 'when user clicks a hash-only link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '#panel-5',
+      expectedHref: '#panel-5',
+    },
+    {
+      title: 'when user clicks a protocol-relative link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '//cdn.example.com/path',
+      expectedHref: '//cdn.example.com/path',
+    },
+    {
+      title: 'when user clicks a mailto link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'mailto:test@example.com',
+      expectedHref: 'mailto:test@example.com',
+    },
+    {
+      title: 'when user clicks a tel link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'tel:+1234567890',
+      expectedHref: 'tel:+1234567890',
+    },
+    {
+      title: 'when user clicks a javascript pseudo-link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'javascript:void(0)',
+      expectedHref: 'javascript:void(0)',
+    },
+    {
+      title: 'when user is not in kiosk mode, clicked link is not modified',
+      currentUrl: '/d/source?orgId=1',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1',
+    },
+    {
+      title: 'when user clicks an external absolute link, kiosk is not appended',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: 'https://example.com/target?orgId=1',
+      expectedHref: 'https://example.com/target?orgId=1',
+    },
+    {
+      title: 'when destination link already defines kiosk mode, user click keeps destination kiosk value',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: '/d/target?kiosk=embed',
+      expectedHref: '/d/target?kiosk=embed',
+    },
+    {
+      title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'https://grafana.acme.com/d/target?orgId=1',
+      expectedHref: 'https://grafana.acme.com/d/target?orgId=1&kiosk=embed',
+    },
+    {
+      title: 'when user is in kiosk mode and clicks a relative dashboard link, kiosk is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1&kiosk=embed',
+    },
+    {
+      title: 'when user is in kiosk mode and clicks a relative dashboard link with hash, kiosk is added and hash is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '/d/target?orgId=1#panel-5',
+      expectedHref: '/d/target?orgId=1&kiosk=embed#panel-5',
+    },
+  ];
+
+  const replaceIdentity: InterpolateFunction = (value) => value;
+  it.each(kioskLinkCases)('$title', ({ currentUrl, linkUrl, expectedHref }) => {
+    window.history.replaceState({}, '', currentUrl);
+
+    const f0 = createDataFrame({
+      name: 'A',
+      fields: [
+        {
+          name: 'message',
+          type: FieldType.string,
+          config: {
+            links: [
+              {
+                url: linkUrl,
+                title: 'target',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const supplier = getLinksSupplier(f0, f0.fields[0], {}, replaceIdentity);
+    const links = supplier({});
+
+    expect(links).toHaveLength(1);
+    expect(links[0].href).toBe(expectedHref);
+  });
 });
 
 describe('applyRawFieldOverrides', () => {

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1380,8 +1380,7 @@ describe('getLinksSupplier', () => {
       expectedHref: '/d/target?orgId=1&kiosk=embed#panel-5',
     },
     {
-      title:
-        'when destination query contains special characters, link values are encoded and kiosk is preserved',
+      title: 'when destination query contains special characters, link values are encoded and kiosk is preserved',
       currentUrl: '/d/source?kiosk=embed',
       linkUrl: '/d/target?query=hello%20world&path=a%2Fb#panel-5',
       expectedHref: '/d/target?query=hello%20world&path=a%2Fb&kiosk=embed#panel-5',

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -463,9 +463,8 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
 };
 
 function preserveKioskModeInDataLink(href: string): string {
-  const isNonBrowserEnvironment = typeof window === 'undefined';
   if (
-    isNonBrowserEnvironment ||
+    isNonBrowserEnvironment() ||
     isHashOrProtocolRelativeHref(href) ||
     isNonNavigableSchemeHref(href) ||
     isExternalAbsoluteUrl(href)
@@ -499,6 +498,10 @@ function preserveKioskModeInDataLink(href: string): string {
   const separator = hrefWithoutHash.endsWith('?') ? '' : hrefWithoutHash.includes('?') ? '&' : '?';
 
   return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(currentKiosk)}${hash}`;
+}
+
+function isNonBrowserEnvironment(): boolean {
+  return typeof window === 'undefined';
 }
 
 function isHashOrProtocolRelativeHref(href: string): boolean {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -487,6 +487,11 @@ function preserveKioskModeInDataLink(href: string): string {
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
   if (
     !currentKiosk
+    /*
+    * The following are the valid kiosk values accepted by Grafana's router (KioskMode enum).
+    * Without this check, unsanitized input from window.location flows into the returned URL,
+    * which Snyk flags as a ReDoS/injection risk.
+    */
     || !['tv', 'embed', 'full', 'true', '1'].includes(currentKiosk)
   ) {
     return href;

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -492,7 +492,7 @@ function preserveKioskModeInDataLink(href: string): string {
      * Without this check, unsanitized input from window.location flows into the returned URL,
      * which Snyk flags as a ReDoS/injection risk.
      */
-    !['tv', 'embed', 'full', 'true', '1'].includes(currentKiosk)
+    !['embed', 'true', '1'].includes(currentKiosk)
   ) {
     return href;
   }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -486,10 +486,7 @@ function preserveKioskModeInDataLink(href: string): string {
   }
 
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
-  if (
-    currentKiosk === null
-    || !['true', 'embed'].includes(currentKiosk)
-  ) {
+  if (!currentKiosk || !isAlphanumericValue(currentKiosk)) {
     return href;
   }
 
@@ -526,6 +523,10 @@ function isExternalAbsoluteUrl(href: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isAlphanumericValue(value: string): boolean {
+  return /^[a-zA-Z0-9_-]{1,50}$/.test(value);
 }
 
 export const getLinksSupplier =

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -512,7 +512,6 @@ function isNonNavigableSchemeHref(href: string): boolean {
     const scheme = new URL(href).protocol;
     return scheme === 'mailto:' || scheme === 'tel:' || scheme === 'javascript:';
   } catch {
-    // Relative URLs don't have these schemes
     return false;
   }
 }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -486,13 +486,13 @@ function preserveKioskModeInDataLink(href: string): string {
 
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
   if (
-    !currentKiosk
+    !currentKiosk ||
     /*
-    * The following are the valid kiosk values accepted by Grafana's router (KioskMode enum).
-    * Without this check, unsanitized input from window.location flows into the returned URL,
-    * which Snyk flags as a ReDoS/injection risk.
-    */
-    || !['tv', 'embed', 'full', 'true', '1'].includes(currentKiosk)
+     * The following are the valid kiosk values accepted by Grafana's router (KioskMode enum).
+     * Without this check, unsanitized input from window.location flows into the returned URL,
+     * which Snyk flags as a ReDoS/injection risk.
+     */
+    !['tv', 'embed', 'full', 'true', '1'].includes(currentKiosk)
   ) {
     return href;
   }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -481,7 +481,6 @@ function preserveKioskModeInDataLink(href: string): string {
     return href;
   }
 
-
   const linkAlreadyDefinesKiosk = parsedHref.searchParams.has('kiosk');
   if (linkAlreadyDefinesKiosk) {
     return href;

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -448,7 +448,7 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
   const { link, linkModel, dataLinkScopedVars, field, replaceVariables } = options;
 
   if (link.internal) {
-    return mapInternalLinkToExplore({
+    const exploreLink = mapInternalLinkToExplore({
       link,
       internalLink: link.internal,
       scopedVars: dataLinkScopedVars,
@@ -456,6 +456,8 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
       range: link.internal.range,
       replaceVariables,
     });
+    exploreLink.href = preserveKioskModeInDataLink(exploreLink.href);
+    return exploreLink;
   } else {
     return linkModel;
   }
@@ -502,13 +504,20 @@ function preserveKioskModeInDataLink(href: string): string {
   const kioskValue = typeof currentKiosk === 'string'
     ? currentKiosk
     : String(currentKiosk);
-  parsedHref.searchParams.set('kiosk', kioskValue);
 
-  if (hasUriScheme) {
-    return parsedHref.toString();
-  }
+  const hashIndex = href.indexOf('#');
 
-  return `${parsedHref.pathname}${parsedHref.search}${parsedHref.hash}`;
+  const hrefWithoutHash = hashIndex >= 0
+    ? href.slice(0, hashIndex)
+    : href;
+
+  const hash = hashIndex >= 0 ? href.slice(hashIndex) : '';
+
+  const separator = hrefWithoutHash.endsWith('?')
+    ? ''
+    : hrefWithoutHash.includes('?') ? '&' : '?';
+
+  return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(kioskValue)}${hash}`;
 }
 
 function isHashOrProtocolRelativeHref(href: string): boolean {
@@ -572,8 +581,7 @@ export const getLinksSupplier =
         href = replaceVariables(href, dataLinkScopedVars, VariableFormatID.UriEncode);
 
         if (href?.length > 0) {
-          href = locationUtil.processUrl(href);
-          href = preserveKioskModeInDataLink(href);
+          href = preserveKioskModeInDataLink(locationUtil.processUrl(href));
         }
       }
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -485,7 +485,7 @@ function preserveKioskModeInDataLink(href: string): string {
   }
 
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
-  if (!currentKiosk || !isAlphanumericValue(currentKiosk)) {
+  if (!currentKiosk || !isValidKioskMode(currentKiosk)) {
     return href;
   }
 
@@ -528,8 +528,9 @@ function isExternalAbsoluteUrl(href: string): boolean {
   }
 }
 
-function isAlphanumericValue(value: string): boolean {
-  return /^[a-zA-Z0-9_-]{1,50}$/.test(value);
+function isValidKioskMode(kiosk: string): boolean {
+  const validKioskModes = ['tv', 'embed', 'full', 'true', '1'];
+  return validKioskModes.includes(kiosk);
 }
 
 export const getLinksSupplier =

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -485,7 +485,10 @@ function preserveKioskModeInDataLink(href: string): string {
   }
 
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
-  if (!currentKiosk || !isValidKioskMode(currentKiosk)) {
+  if (
+    !currentKiosk
+    || !['tv', 'embed', 'full', 'true', '1'].includes(currentKiosk)
+  ) {
     return href;
   }
 
@@ -526,11 +529,6 @@ function isExternalAbsoluteUrl(href: string): boolean {
   } catch {
     return false;
   }
-}
-
-function isValidKioskMode(kiosk: string): boolean {
-  const validKioskModes = ['tv', 'embed', 'full', 'true', '1'];
-  return validKioskModes.includes(kiosk);
 }
 
 export const getLinksSupplier =

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -508,12 +508,13 @@ function isHashOrProtocolRelativeHref(href: string): boolean {
 }
 
 function isNonNavigableSchemeHref(href: string): boolean {
-  const lowerHref = href.toLowerCase();
-  const isMailtoLink = lowerHref.startsWith('mailto:');
-  const isTelLink = lowerHref.startsWith('tel:');
-  const isJavascriptPseudoLink = lowerHref.startsWith('javascript:');
-
-  return isMailtoLink || isTelLink || isJavascriptPseudoLink;
+  try {
+    const scheme = new URL(href).protocol;
+    return scheme === 'mailto:' || scheme === 'tel:' || scheme === 'javascript:';
+  } catch {
+    // Relative URLs don't have these schemes
+    return false;
+  }
 }
 
 function isExternalAbsoluteUrl(href: string): boolean {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -465,10 +465,10 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
 function preserveKioskModeInDataLink(href: string): string {
   const isNonBrowserEnvironment = typeof window === 'undefined';
   if (
-    isNonBrowserEnvironment
-    || isHashOrProtocolRelativeHref(href)
-    || isNonNavigableSchemeHref(href)
-    || isExternalAbsoluteUrl(href)
+    isNonBrowserEnvironment ||
+    isHashOrProtocolRelativeHref(href) ||
+    isNonNavigableSchemeHref(href) ||
+    isExternalAbsoluteUrl(href)
   ) {
     return href;
   }
@@ -492,15 +492,11 @@ function preserveKioskModeInDataLink(href: string): string {
 
   const hashIndex = href.indexOf('#');
 
-  const hrefWithoutHash = hashIndex >= 0
-    ? href.slice(0, hashIndex)
-    : href;
+  const hrefWithoutHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
 
   const hash = hashIndex >= 0 ? href.slice(hashIndex) : '';
 
-  const separator = hrefWithoutHash.endsWith('?')
-    ? ''
-    : hrefWithoutHash.includes('?') ? '&' : '?';
+  const separator = hrefWithoutHash.endsWith('?') ? '' : hrefWithoutHash.includes('?') ? '&' : '?';
 
   return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(currentKiosk)}${hash}`;
 }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -29,7 +29,6 @@ import { TimeZone } from '../types/time';
 import { FieldMatcher } from '../types/transformations';
 import { mapInternalLinkToExplore } from '../utils/dataLinks';
 import { locationUtil } from '../utils/location';
-import { urlUtil } from '../utils/url';
 
 import { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
@@ -486,18 +485,10 @@ function preserveKioskModeInDataLink(href: string): string {
     return href;
   }
 
-  const currentParams = urlUtil.parseKeyValue(window.location.search.substring(1));
-  const currentKiosk = currentParams.kiosk;
-  const hasKioskInCurrentUrl = currentKiosk !== undefined
-    && currentKiosk !== null
-    && currentKiosk !== false;
-  if (!hasKioskInCurrentUrl) {
+  const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
+  if (currentKiosk === null) {
     return href;
   }
-
-  const kioskValue = typeof currentKiosk === 'string'
-    ? currentKiosk
-    : String(currentKiosk);
 
   const hashIndex = href.indexOf('#');
 
@@ -511,7 +502,7 @@ function preserveKioskModeInDataLink(href: string): string {
     ? ''
     : hrefWithoutHash.includes('?') ? '&' : '?';
 
-  return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(kioskValue)}${hash}`;
+  return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(currentKiosk)}${hash}`;
 }
 
 function isHashOrProtocolRelativeHref(href: string): boolean {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -486,7 +486,10 @@ function preserveKioskModeInDataLink(href: string): string {
   }
 
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
-  if (currentKiosk === null) {
+  if (
+    currentKiosk === null
+    || ['true', 'embed'].includes(currentKiosk)
+  ) {
     return href;
   }
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -469,16 +469,8 @@ function preserveKioskModeInDataLink(href: string): string {
     isNonBrowserEnvironment
     || isHashOrProtocolRelativeHref(href)
     || isNonNavigableSchemeHref(href)
+    || isExternalAbsoluteUrl(href)
   ) {
-    return href;
-  }
-
-  const currentParams = urlUtil.parseKeyValue(window.location.search.substring(1));
-  const currentKiosk = currentParams.kiosk;
-  const hasKioskInCurrentUrl = currentKiosk !== undefined
-    && currentKiosk !== null
-    && currentKiosk !== false;
-  if (!hasKioskInCurrentUrl) {
     return href;
   }
 
@@ -489,15 +481,18 @@ function preserveKioskModeInDataLink(href: string): string {
     return href;
   }
 
-  const hasUriScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(href);
-  const isExternalAbsoluteUrl = hasUriScheme
-    && parsedHref.origin !== window.location.origin;
-  if (isExternalAbsoluteUrl) {
-    return href;
-  }
 
   const linkAlreadyDefinesKiosk = parsedHref.searchParams.has('kiosk');
   if (linkAlreadyDefinesKiosk) {
+    return href;
+  }
+
+  const currentParams = urlUtil.parseKeyValue(window.location.search.substring(1));
+  const currentKiosk = currentParams.kiosk;
+  const hasKioskInCurrentUrl = currentKiosk !== undefined
+    && currentKiosk !== null
+    && currentKiosk !== false;
+  if (!hasKioskInCurrentUrl) {
     return href;
   }
 
@@ -533,6 +528,15 @@ function isNonNavigableSchemeHref(href: string): boolean {
   const isJavascriptPseudoLink = lowerHref.startsWith('javascript:');
 
   return isMailtoLink || isTelLink || isJavascriptPseudoLink;
+}
+
+function isExternalAbsoluteUrl(href: string): boolean {
+  try {
+    const absoluteUrl = new URL(href);
+    return absoluteUrl.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
 }
 
 export const getLinksSupplier =

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -488,7 +488,7 @@ function preserveKioskModeInDataLink(href: string): string {
   const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
   if (
     currentKiosk === null
-    || ['true', 'embed'].includes(currentKiosk)
+    || !['true', 'embed'].includes(currentKiosk)
   ) {
     return href;
   }
@@ -574,7 +574,8 @@ export const getLinksSupplier =
         href = replaceVariables(href, dataLinkScopedVars, VariableFormatID.UriEncode);
 
         if (href?.length > 0) {
-          href = preserveKioskModeInDataLink(locationUtil.processUrl(href));
+          href = locationUtil.processUrl(href);
+          href = preserveKioskModeInDataLink(href);
         }
       }
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -29,6 +29,7 @@ import { TimeZone } from '../types/time';
 import { FieldMatcher } from '../types/transformations';
 import { mapInternalLinkToExplore } from '../utils/dataLinks';
 import { locationUtil } from '../utils/location';
+import { urlUtil } from '../utils/url';
 
 import { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
@@ -460,6 +461,71 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
   }
 };
 
+function preserveKioskModeInDataLink(href: string): string {
+  const isNonBrowserEnvironment = typeof window === 'undefined';
+  if (
+    isNonBrowserEnvironment
+    || isHashOrProtocolRelativeHref(href)
+    || isNonNavigableSchemeHref(href)
+  ) {
+    return href;
+  }
+
+  const currentParams = urlUtil.parseKeyValue(window.location.search.substring(1));
+  const currentKiosk = currentParams.kiosk;
+  const hasKioskInCurrentUrl = currentKiosk !== undefined
+    && currentKiosk !== null
+    && currentKiosk !== false;
+  if (!hasKioskInCurrentUrl) {
+    return href;
+  }
+
+  let parsedHref: URL;
+  try {
+    parsedHref = new URL(href, window.location.origin);
+  } catch {
+    return href;
+  }
+
+  const hasUriScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(href);
+  const isExternalAbsoluteUrl = hasUriScheme
+    && parsedHref.origin !== window.location.origin;
+  if (isExternalAbsoluteUrl) {
+    return href;
+  }
+
+  const linkAlreadyDefinesKiosk = parsedHref.searchParams.has('kiosk');
+  if (linkAlreadyDefinesKiosk) {
+    return href;
+  }
+
+  const kioskValue = typeof currentKiosk === 'string'
+    ? currentKiosk
+    : String(currentKiosk);
+  parsedHref.searchParams.set('kiosk', kioskValue);
+
+  if (hasUriScheme) {
+    return parsedHref.toString();
+  }
+
+  return `${parsedHref.pathname}${parsedHref.search}${parsedHref.hash}`;
+}
+
+function isHashOrProtocolRelativeHref(href: string): boolean {
+  const isHashOnlyLink = href.startsWith('#');
+  const isProtocolRelativeLink = href.startsWith('//');
+  return isHashOnlyLink || isProtocolRelativeLink;
+}
+
+function isNonNavigableSchemeHref(href: string): boolean {
+  const lowerHref = href.toLowerCase();
+  const isMailtoLink = lowerHref.startsWith('mailto:');
+  const isTelLink = lowerHref.startsWith('tel:');
+  const isJavascriptPseudoLink = lowerHref.startsWith('javascript:');
+
+  return isMailtoLink || isTelLink || isJavascriptPseudoLink;
+}
+
 export const getLinksSupplier =
   (
     frame: DataFrame,
@@ -507,6 +573,7 @@ export const getLinksSupplier =
 
         if (href?.length > 0) {
           href = locationUtil.processUrl(href);
+          href = preserveKioskModeInDataLink(href);
         }
       }
 


### PR DESCRIPTION
### What is this feature?
Preserve kiosk mode when users navigate through dashboard data links, so kiosk/embed experiences remain consistent.

When the current dashboard URL includes kiosk mode, eligible internal data links carry that kiosk value forward unless the destination link already defines its own kiosk value.

[Demo.webm](https://github.com/user-attachments/assets/d9d695f1-6b87-46a7-b617-089fbc1d3195)


### Why do we need this feature?
Without this behavior, users can unintentionally leave kiosk/embed context when clicking data links, which can change page chrome and navigation behavior unexpectedly.

Preserving kiosk mode keeps the navigation flow consistent, especially for embedded dashboards where a focused presentation is expected.

### Who is this feature for?
This feature is for users viewing dashboards in kiosk or embedded contexts, and for app integrators embedding Grafana dashboards in iframes.

### Special notes for your reviewer
Please verify that:
- [ ] Internal links preserve kiosk mode only when appropriate.
- [ ] Destination links with explicit kiosk values remain unchanged.
- [ ] External and non-navigable links are untouched.
- [ ] Hash fragments remain intact after kiosk append.