### PR TITLE
Data links: preserve kiosk mode during internal navigation

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1253,6 +1253,123 @@ describe('getLinksSupplier', () => {
     // check that onClick variable replacer has scoped vars bound to it
     expect(replaceSpy.mock.calls[1][1]).toHaveProperty('foo', { text: 'bar', value: 'bar' });
   });
+
+  const kioskLinkCases = [
+    {
+      title: 'when user clicks a hash-only link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '#panel-5',
+      expectedHref: '#panel-5',
+    },
+    {
+      title: 'when user clicks a protocol-relative link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '//cdn.example.com/path',
+      expectedHref: '//cdn.example.com/path',
+    },
+    {
+      title: 'when user clicks a mailto link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'mailto:test@example.com',
+      expectedHref: 'mailto:test@example.com',
+    },
+    {
+      title: 'when user clicks a tel link, kiosk logic does not modify it',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'tel:+1234567890',
+      expectedHref: 'tel:+1234567890',
+    },
+    {
+      title: 'when user clicks a javascript pseudo-link, sanitized href is not modified by kiosk logic',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'javascript:void(0)',
+      expectedHref: 'about:blank',
+    },
+    {
+      title: 'when user clicks an external absolute link, kiosk is not appended',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: 'https://example.com/target?orgId=1',
+      expectedHref: 'https://example.com/target?orgId=1',
+    },
+    {
+      title: 'when destination link already defines kiosk mode, user click keeps destination kiosk value',
+      currentUrl: '/d/source?kiosk=true',
+      linkUrl: '/d/target?kiosk=embed',
+      expectedHref: '/d/target?kiosk=embed',
+    },
+    {
+      title: 'when user is not in kiosk mode, clicked link is not modified',
+      currentUrl: '/d/source?orgId=1',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1',
+    },
+    {
+      title: 'when user is in kiosk mode and clicks a same-origin absolute link, kiosk is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: 'http://localhost/d/target?orgId=1',
+      expectedHref: 'http://localhost/d/target?orgId=1&kiosk=embed',
+    },
+    {
+      title: 'when user is in kiosk mode and clicks a relative dashboard link, kiosk is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '/d/target?orgId=1',
+      expectedHref: '/d/target?orgId=1&kiosk=embed',
+    },
+    {
+      title:
+        'when user is in kiosk mode and clicks a relative dashboard link with hash, kiosk is added and hash is preserved',
+      currentUrl: '/d/source?kiosk=embed',
+      linkUrl: '/d/target?orgId=1#panel-5',
+      expectedHref: '/d/target?orgId=1&kiosk=embed#panel-5',
+    },
+  ];
+
+  const replaceIdentity: InterpolateFunction = (value) => value;
+  describe('kiosk mode preservation', () => {
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    afterEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/subUrl' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    it.each(kioskLinkCases)('$title', ({ currentUrl, linkUrl, expectedHref }) => {
+      window.history.replaceState({}, '', currentUrl);
+
+      const dataframe = createDataFrame({
+        name: 'A',
+        fields: [
+          {
+            name: 'message',
+            type: FieldType.string,
+            config: {
+              links: [
+                {
+                  url: linkUrl,
+                  title: 'target',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const supplier = getLinksSupplier(dataframe, dataframe.fields[0], {}, replaceIdentity);
+      const links = supplier({});
+
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toBe(expectedHref);
+    });
+  });
 });
 
 describe('applyRawFieldOverrides', () => {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -447,7 +447,7 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
   const { link, linkModel, dataLinkScopedVars, field, replaceVariables } = options;
 
   if (link.internal) {
-    return mapInternalLinkToExplore({
+    const exploreLink = mapInternalLinkToExplore({
       link,
       internalLink: link.internal,
       scopedVars: dataLinkScopedVars,
@@ -455,10 +455,75 @@ const defaultInternalLinkPostProcessor: DataLinkPostProcessor = (options) => {
       range: link.internal.range,
       replaceVariables,
     });
+    exploreLink.href = preserveKioskModeInDataLink(exploreLink.href);
+    return exploreLink;
   } else {
     return linkModel;
   }
 };
+
+function preserveKioskModeInDataLink(href: string): string {
+  const isNonBrowserEnvironment = typeof window === 'undefined';
+  if (
+    isNonBrowserEnvironment ||
+    isHashOrProtocolRelativeHref(href) ||
+    isNonNavigableSchemeHref(href) ||
+    isExternalAbsoluteUrl(href)
+  ) {
+    return href;
+  }
+
+  let parsedHref: URL;
+  try {
+    parsedHref = new URL(href, window.location.origin);
+  } catch {
+    return href;
+  }
+
+  const linkAlreadyDefinesKiosk = parsedHref.searchParams.has('kiosk');
+  if (linkAlreadyDefinesKiosk) {
+    return href;
+  }
+
+  const currentKiosk = new URLSearchParams(window.location.search).get('kiosk');
+  if (currentKiosk === null) {
+    return href;
+  }
+
+  const hashIndex = href.indexOf('#');
+
+  const hrefWithoutHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
+
+  const hash = hashIndex >= 0 ? href.slice(hashIndex) : '';
+
+  const separator = hrefWithoutHash.endsWith('?') ? '' : hrefWithoutHash.includes('?') ? '&' : '?';
+
+  return `${hrefWithoutHash}${separator}kiosk=${encodeURIComponent(currentKiosk)}${hash}`;
+}
+
+function isHashOrProtocolRelativeHref(href: string): boolean {
+  const isHashOnlyLink = href.startsWith('#');
+  const isProtocolRelativeLink = href.startsWith('//');
+  return isHashOnlyLink || isProtocolRelativeLink;
+}
+
+function isNonNavigableSchemeHref(href: string): boolean {
+  try {
+    const scheme = new URL(href).protocol;
+    return scheme === 'mailto:' || scheme === 'tel:' || scheme === 'javascript:';
+  } catch {
+    return false;
+  }
+}
+
+function isExternalAbsoluteUrl(href: string): boolean {
+  try {
+    const absoluteUrl = new URL(href);
+    return absoluteUrl.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
 
 export const getLinksSupplier =
   (
@@ -506,7 +571,7 @@ export const getLinksSupplier =
         href = replaceVariables(href, dataLinkScopedVars, VariableFormatID.UriEncode);
 
         if (href?.length > 0) {
-          href = locationUtil.processUrl(href);
+          href = preserveKioskModeInDataLink(locationUtil.processUrl(href));
         }
       }
 


### PR DESCRIPTION
### What is this feature?
Preserve kiosk mode when users navigate through dashboard data links, so kiosk/embed experiences remain consistent.

When the current dashboard URL includes kiosk mode, eligible internal data links carry that kiosk value forward unless the destination link already defines its own kiosk value.

[Demo.webm](https://github.com/user-attachments/assets/d9d695f1-6b87-46a7-b617-089fbc1d3195)


### Why do we need this feature?
Without this behavior, users can unintentionally leave kiosk/embed context when clicking data links, which can change page chrome and navigation behavior unexpectedly.

Preserving kiosk mode keeps the navigation flow consistent, especially for embedded dashboards where a focused presentation is expected.

### Who is this feature for?
This feature is for users viewing dashboards in kiosk or embedded contexts, and for app integrators embedding Grafana dashboards in iframes.

### Special notes for your reviewer
Please verify that:
- [ ] Internal links preserve kiosk mode only when appropriate.
- [ ] Destination links with explicit kiosk values remain unchanged.
- [ ] External and non-navigable links are untouched.
- [ ] Hash fragments remain intact after kiosk append.